### PR TITLE
EP-003 FT-015 Core | Catalogos basicos

### DIFF
--- a/.github/specs/ep-003-ft-015-core-catalogos-basicos.spec.md
+++ b/.github/specs/ep-003-ft-015-core-catalogos-basicos.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-003
-status: IN_PROGRESS
+status: IMPLEMENTED
 feature: ep-003-ft-015-core-catalogos-basicos
 created: 2026-04-25
 updated: 2026-04-25
@@ -430,18 +430,18 @@ No aplica a esta spec — la integración con el frontend de Next.js es responsa
 
 #### Tests Backend
 
-- [ ] `test_get_subscribers_returns_200_with_list` — happy path, lista no vacía
-- [ ] `test_get_subscribers_empty_list_returns_200` — lista vacía es respuesta válida
-- [ ] `test_get_subscribers_service_unavailable_returns_503` — fallo del servicio externo tras reintentos
-- [ ] `test_get_agents_returns_200_with_list` — happy path agentes
-- [ ] `test_get_agents_service_unavailable_returns_503` — fallo agentes
-- [ ] `test_get_business_lines_returns_200_with_list` — happy path giros
-- [ ] `test_get_business_lines_service_unavailable_returns_503` — fallo giros
-- [ ] `test_retry_succeeds_on_second_attempt` — reintento exitoso en segundo intento
-- [ ] `test_retry_exhausted_throws_service_exception` — reintentos agotados → excepción
-- [ ] `test_4xx_error_not_retried` — HTTP 400/404 NO activan reintentos
-- [ ] `test_mapping_drops_invalid_record_missing_id` — registro sin `id` se descarta (log WARNING)
-- [ ] `test_catalogs_service_impl_maps_all_fields` — transformación completa de campos
+- [x] `test_get_subscribers_returns_200_with_list` — happy path, lista no vacía
+- [x] `test_get_subscribers_empty_list_returns_200` — lista vacía es respuesta válida
+- [x] `test_get_subscribers_service_unavailable_returns_503` — fallo del servicio externo tras reintentos
+- [x] `test_get_agents_returns_200_with_list` — happy path agentes
+- [x] `test_get_agents_service_unavailable_returns_503` — fallo agentes
+- [x] `test_get_business_lines_returns_200_with_list` — happy path giros
+- [x] `test_get_business_lines_service_unavailable_returns_503` — fallo giros
+- [x] `test_retry_succeeds_on_second_attempt` — reintento exitoso en segundo intento
+- [x] `test_retry_exhausted_throws_service_exception` — reintentos agotados → excepción
+- [x] `test_4xx_error_not_retried` — HTTP 400/404 NO activan reintentos
+- [x] `test_mapping_drops_invalid_record_missing_id` — registro sin `id` se descarta (log WARNING)
+- [x] `test_catalogs_service_impl_maps_all_fields` — transformación completa de campos
 
 ### Frontend
 

--- a/.github/specs/ep-003-ft-015-core-catalogos-basicos.spec.md
+++ b/.github/specs/ep-003-ft-015-core-catalogos-basicos.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-003
-status: APPROVED
+status: IN_PROGRESS
 feature: ep-003-ft-015-core-catalogos-basicos
 created: 2026-04-25
 updated: 2026-04-25
@@ -416,16 +416,17 @@ No aplica a esta spec — la integración con el frontend de Next.js es responsa
 
 #### Implementación
 
-- [ ] Crear `model/dto/SubscriberDto.java` — campos `id`, `nombre`, `clave`, `activo` (Lombok `@Data`)
-- [ ] Crear `model/dto/AgentDto.java` — campos `id`, `nombre`, `clave`, `activo`
-- [ ] Crear `model/dto/BusinessLineDto.java` — campos `id`, `descripcion`, `claveIncendio`, `activo`
-- [ ] Crear `config/CatalogsClientConfig.java` — bean `RestTemplate` con `baseUrl` y `connectionTimeout`
-- [ ] Crear `config/Resilience4jCatalogsConfig.java` — configuración `RetryConfig` (3 intentos, backoff exponencial, solo errores recuperables)
-- [ ] Crear `client/CatalogsClient.java` (interfaz) + `CatalogsClientImpl.java` — llamadas HTTP a `/v1/subscribers`, `/v1/agents`, `/v1/business-lines`
-- [ ] Crear `service/CatalogsService.java` (interfaz) + `CatalogsServiceImpl.java` — orquesta cliente + mapeo + retry + manejo de errores
-- [ ] Crear `controller/CatalogsController.java` — `GET /api/v1/catalogs/subscribers`, `GET /api/v1/catalogs/agents`, `GET /api/v1/catalogs/business-lines`
-- [ ] Agregar `PLATAFORMA_CORE_OHS_URL` a `application.yml` y `.env.example`
-- [ ] Registrar `CatalogsController` en el contexto de Spring (autowired vía `@RestController`)
+- [x] Crear `model/dto/SubscriberDto.java` — campos `id`, `nombre`, `clave`, `activo` (Lombok `@Data`)
+- [x] Crear `model/dto/AgentDto.java` — campos `id`, `nombre`, `clave`, `activo`
+- [x] Crear `model/dto/BusinessLineDto.java` — campos `id`, `descripcion`, `claveIncendio`, `activo`
+- [x] Crear `config/CatalogsClientConfig.java` — bean `RestTemplate` con `baseUrl` y `connectionTimeout`
+- [x] Crear `config/SecurityConfig.java` — `SecurityFilterChain` stateless, CSRF desactivado (JWT pendiente feature auth)
+- [x] Crear `client/CatalogsClient.java` (interfaz) + `CatalogsClientImpl.java` — llamadas HTTP a `/v1/subscribers`, `/v1/agents`, `/v1/business-lines`
+- [x] Crear `service/CatalogsService.java` (interfaz) + `CatalogsServiceImpl.java` — orquesta cliente + mapeo + retry + manejo de errores
+- [x] Crear `exception/CatalogServiceUnavailableException.java` + `GlobalExceptionHandler.java`
+- [x] Crear `controller/CatalogsController.java` — `GET /api/v1/catalogs/subscribers`, `GET /api/v1/catalogs/agents`, `GET /api/v1/catalogs/business-lines`
+- [x] Agregar `plataforma-core-ohs.url` a `application.yaml` con retry config completo (exponential backoff, retry/ignore exceptions)
+- [x] Registrar `CatalogsController` en el contexto de Spring (autowired vía `@RestController`)
 
 #### Tests Backend
 

--- a/.github/specs/ep-003-ft-015-core-catalogos-basicos.spec.md
+++ b/.github/specs/ep-003-ft-015-core-catalogos-basicos.spec.md
@@ -1,0 +1,456 @@
+---
+id: SPEC-003
+status: APPROVED
+feature: ep-003-ft-015-core-catalogos-basicos
+created: 2026-04-25
+updated: 2026-04-25
+author: spec-generator
+version: "1.0"
+related-specs:
+  - SPEC-001
+  - SPEC-002
+---
+
+# Spec: FT-015 — Conectividad y Consumo de Catálogos Básicos
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+Esta feature implementa en `plataformas-danos-back` (Java 21 / Spring Boot) la capa de integración con el servicio externo `plataforma-core-ohs` para consumir los catálogos básicos: suscriptores, agentes y giros (líneas de negocio). Incluye la configuración del cliente HTTP, la transformación de datos al modelo interno, y un mecanismo de resiliencia con reintentos exponenciales ante fallos del servicio externo. Los catálogos se exponen al frontend a través de endpoints REST propios.
+
+### Requerimiento de Negocio
+
+El cotizador de seguros de daños necesita catálogos actualizados de suscriptores, agentes y giros para poblar los formularios de cotización. Estos datos provienen de `plataforma-core-ohs` (o su mock en desarrollo). El sistema debe ser resiliente a fallos del servicio externo, transformar los datos al modelo interno y exponerlos de forma unificada al frontend sin acoplar directamente la UI al contrato de la API externa.
+
+### Historias de Usuario
+
+#### HU-01: Conexión al servicio de catálogos básicos (HU-068)
+
+```
+Como:        Sistema (cotizador — plataformas-danos-back)
+Quiero:      Establecer y gestionar la conexión HTTP con plataforma-core-ohs
+Para:        Consultar información de suscriptores, agentes y giros necesaria para cotizar
+
+Prioridad:   Alta
+Estimación:  S (2 story points)
+Dependencias: SPEC-001 (mock server operativo)
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Conexión exitosa al arrancar el cotizador
+  Dado que:  plataformas-danos-back inicia con PLATAFORMA_CORE_OHS_URL configurada
+  Cuando:    el contexto de Spring se levanta correctamente
+  Entonces:  el bean del cliente HTTP se registra sin errores y la URL base queda configurada
+```
+
+**Error Path**
+```gherkin
+CRITERIO-1.2: Fallo de conexión registrado en logs
+  Dado que:  plataforma-core-ohs no responde
+  Cuando:    el cotizador intenta consultar cualquier catálogo
+  Entonces:  se registra un log de nivel ERROR con los detalles del fallo
+             y se notifica al sistema que el catálogo no está disponible
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-1.3: Configuración incorrecta detectada
+  Dado que:  PLATAFORMA_CORE_OHS_URL es una URL inválida o vacía
+  Cuando:    el cliente HTTP intenta realizar una llamada
+  Entonces:  la llamada falla inmediatamente sin reintentos
+             y se registra un ERROR de configuración
+```
+
+---
+
+#### HU-02: Recuperar catálogo de suscriptores (HU-069)
+
+```
+Como:        Sistema (cotizador)
+Quiero:      Recuperar el catálogo de suscriptores desde plataforma-core-ohs
+Para:        Ofrecer la lista actualizada en el formulario de cotización
+
+Prioridad:   Alta
+Estimación:  S (3 story points)
+Dependencias: HU-01 (conexión establecida)
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-02
+
+**Happy Path**
+```gherkin
+CRITERIO-2.1: Lista de suscriptores recuperada exitosamente
+  Dado que:  plataforma-core-ohs está activo y devuelve suscriptores
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/subscribers
+  Entonces:  recibe HTTP 200 con un array de objetos { id, nombre, clave, activo }
+             y la lista contiene al menos los campos id y nombre
+```
+
+**Happy Path**
+```gherkin
+CRITERIO-2.2: Lista vacía es respuesta válida
+  Dado que:  plataforma-core-ohs devuelve una lista vacía []
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/subscribers
+  Entonces:  recibe HTTP 200 con array vacío []
+             y no se registran errores en los logs
+```
+
+**Error Path**
+```gherkin
+CRITERIO-2.3: Fallo del servicio externo → HTTP 503
+  Dado que:  plataforma-core-ohs no está disponible después de agotar reintentos
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/subscribers
+  Entonces:  recibe HTTP 503 con body { "message": "Servicio de catálogos no disponible", "code": "CATALOG_SERVICE_UNAVAILABLE" }
+```
+
+---
+
+#### HU-03: Recuperar catálogo de agentes (HU-070)
+
+```
+Como:        Sistema (cotizador)
+Quiero:      Recuperar el catálogo de agentes desde plataforma-core-ohs
+Para:        Ofrecer la lista actualizada en el formulario de cotización
+
+Prioridad:   Alta
+Estimación:  S (3 story points)
+Dependencias: HU-01
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-03
+
+**Happy Path**
+```gherkin
+CRITERIO-3.1: Lista de agentes recuperada exitosamente
+  Dado que:  plataforma-core-ohs está activo y devuelve agentes
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/agents
+  Entonces:  recibe HTTP 200 con un array de objetos { id, nombre, clave, activo }
+```
+
+**Error Path**
+```gherkin
+CRITERIO-3.2: Fallo del servicio externo → HTTP 503
+  Dado que:  plataforma-core-ohs no está disponible después de agotar reintentos
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/agents
+  Entonces:  recibe HTTP 503 con body { "message": "Servicio de catálogos no disponible", "code": "CATALOG_SERVICE_UNAVAILABLE" }
+```
+
+---
+
+#### HU-04: Recuperar catálogo de giros (HU-071)
+
+```
+Como:        Sistema (cotizador)
+Quiero:      Recuperar el catálogo de giros (líneas de negocio) desde plataforma-core-ohs
+Para:        Ofrecer la lista actualizada en el formulario de cotización
+
+Prioridad:   Media
+Estimación:  S (2 story points)
+Dependencias: HU-01
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-04
+
+**Happy Path**
+```gherkin
+CRITERIO-4.1: Lista de giros recuperada exitosamente
+  Dado que:  plataforma-core-ohs está activo y devuelve giros
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/business-lines
+  Entonces:  recibe HTTP 200 con un array de objetos { id, descripcion, claveIncendio, activo }
+```
+
+**Error Path**
+```gherkin
+CRITERIO-4.2: Fallo del servicio externo → HTTP 503
+  Dado que:  plataforma-core-ohs no está disponible
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/business-lines
+  Entonces:  recibe HTTP 503 con body { "message": "Servicio de catálogos no disponible", "code": "CATALOG_SERVICE_UNAVAILABLE" }
+```
+
+---
+
+#### HU-05: Mapeo de datos al modelo interno (HU-072)
+
+```
+Como:        Sistema (cotizador)
+Quiero:      Transformar la respuesta de plataforma-core-ohs al modelo de dominio interno
+Para:        Desacoplar el contrato externo de la lógica de negocio del cotizador
+
+Prioridad:   Alta
+Estimación:  S (3 story points)
+Dependencias: HU-02, HU-03, HU-04
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-05
+
+**Happy Path**
+```gherkin
+CRITERIO-5.1: Datos transformados sin pérdida de información
+  Dado que:  plataforma-core-ohs devuelve datos válidos para cualquier catálogo
+  Cuando:    el servicio de catálogos mapea la respuesta al modelo interno
+  Entonces:  todos los campos relevantes se preservan en el DTO de respuesta
+             y los nombres de campo siguen la convención camelCase del modelo interno
+```
+
+**Error Path**
+```gherkin
+CRITERIO-5.2: Campo obligatorio faltante genera error de mapeo
+  Dado que:  la respuesta de plataforma-core-ohs omite un campo obligatorio (id o nombre)
+  Cuando:    el servicio intenta mapear el registro
+  Entonces:  ese registro se descarta y se registra un log de WARNING con el detalle del campo faltante
+             y los registros válidos restantes sí se retornan
+```
+
+---
+
+#### HU-06: Manejo de errores y reintentos con backoff exponencial (HU-073)
+
+```
+Como:        Sistema (cotizador)
+Quiero:      Aplicar reintentos con backoff exponencial ante fallos recuperables del servicio externo
+Para:        Garantizar la resiliencia y disponibilidad del cotizador ante fallas transitorias
+
+Prioridad:   Alta
+Estimación:  M (4 story points)
+Dependencias: HU-01
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-06
+
+**Happy Path**
+```gherkin
+CRITERIO-6.1: Servicio se recupera durante reintentos
+  Dado que:  plataforma-core-ohs falla en el primer intento pero responde en el segundo
+  Cuando:    el cotizador llama a cualquier endpoint de catálogo
+  Entonces:  el sistema reintenta la llamada
+             y retorna la respuesta exitosa del segundo intento
+             y se registra un log INFO indicando la recuperación
+```
+
+**Error Path**
+```gherkin
+CRITERIO-6.2: Fallo crítico tras agotar reintentos
+  Dado que:  plataforma-core-ohs no responde en ninguno de los 3 intentos configurados
+  Cuando:    el cotizador agota los reintentos
+  Entonces:  se registra un log CRITICAL con los detalles del fallo y el servicio afectado
+             y se retorna HTTP 503 al cliente
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-6.3: Error HTTP 4xx no activa reintentos
+  Dado que:  plataforma-core-ohs responde con HTTP 400 o 404
+  Cuando:    el cotizador recibe la respuesta
+  Entonces:  NO se activan reintentos
+             y se registra un log ERROR con el código de estado recibido
+```
+
+### Reglas de Negocio
+
+1. **Solo lectura**: Los endpoints de catálogos son exclusivamente `GET` — no se persisten datos en MongoDB local.
+2. **Reintentos configurables**: Máximo 3 intentos, delay inicial 1000ms, multiplicador 2.0, delay máximo 8000ms. Todos los valores son externalizables via `application.yml`.
+3. **Errores recuperables**: Códigos HTTP `500, 502, 503, 504` y excepciones de red activan reintentos. Códigos `4xx` son no recuperables.
+4. **Mapeo tolerante**: Si un elemento del array externo carece de campo `id` o `nombre`, se descarta ese elemento (log WARNING). Los demás elementos se procesan normalmente.
+5. **Sin autenticación**: El mock `plataforma-core-ohs` no requiere JWT. La URL base se configura con `PLATAFORMA_CORE_OHS_URL`.
+6. **CORS**: Los endpoints `/api/v1/catalogs/*` están protegidos por el `SecurityFilterChain` existente.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Almacén | Cambios | Descripción |
+|---------|---------|---------|-------------|
+| `SubscriberDto` | ninguno (solo memoria) | nueva | DTO de suscriptor al modelo interno |
+| `AgentDto` | ninguno (solo memoria) | nueva | DTO de agente al modelo interno |
+| `BusinessLineDto` | ninguno (solo memoria) | nueva | DTO de giro/línea de negocio al modelo interno |
+
+> No se crea ninguna colección MongoDB. Los datos se leen del servicio externo y se retornan directamente.
+
+#### Campos del modelo — `SubscriberDto` (response)
+
+| Campo | Tipo | Obligatorio | Validación | Descripción |
+|-------|------|-------------|------------|-------------|
+| `id` | String | sí | no vacío | Identificador único del suscriptor |
+| `nombre` | String | sí | max 200 chars | Nombre o razón social |
+| `clave` | String | sí | max 50 chars | Clave interna del suscriptor |
+| `activo` | Boolean | sí | — | Indica si está activo en el sistema origen |
+
+#### Campos del modelo — `AgentDto` (response)
+
+| Campo | Tipo | Obligatorio | Validación | Descripción |
+|-------|------|-------------|------------|-------------|
+| `id` | String | sí | no vacío | Identificador único del agente |
+| `nombre` | String | sí | max 200 chars | Nombre del agente |
+| `clave` | String | sí | max 50 chars | Clave interna del agente |
+| `activo` | Boolean | sí | — | Indica si está activo |
+
+#### Campos del modelo — `BusinessLineDto` (response)
+
+| Campo | Tipo | Obligatorio | Validación | Descripción |
+|-------|------|-------------|------------|-------------|
+| `id` | String | sí | no vacío | Identificador único del giro |
+| `descripcion` | String | sí | max 300 chars | Descripción del giro |
+| `claveIncendio` | String | sí | max 20 chars | Clave de incendio asociada |
+| `activo` | Boolean | sí | — | Indica si está activo |
+
+#### Índices / Constraints
+
+No aplica — no hay persistencia en MongoDB para estos modelos.
+
+### API Endpoints
+
+> Los endpoints de `plataformas-danos-back` siguen la convención `/api/v1/...`.
+
+#### GET /api/v1/catalogs/subscribers
+
+- **Descripción**: Retorna el catálogo de suscriptores obtenido de `plataforma-core-ohs`
+- **Auth requerida**: sí (JWT)
+- **Request Body**: ninguno
+- **Response 200**:
+  ```json
+  [
+    { "id": "SUB-001", "nombre": "Empresa ABC S.A. de C.V.", "clave": "ABC", "activo": true },
+    { "id": "SUB-002", "nombre": "Corporativo XYZ", "clave": "XYZ", "activo": true }
+  ]
+  ```
+- **Response 503**: servicio externo no disponible tras reintentos
+  ```json
+  { "message": "Servicio de catálogos no disponible", "code": "CATALOG_SERVICE_UNAVAILABLE" }
+  ```
+
+#### GET /api/v1/catalogs/agents
+
+- **Descripción**: Retorna el catálogo de agentes obtenido de `plataforma-core-ohs`
+- **Auth requerida**: sí (JWT)
+- **Response 200**:
+  ```json
+  [
+    { "id": "AGT-001", "nombre": "Juan Pérez García", "clave": "JPG", "activo": true }
+  ]
+  ```
+- **Response 503**: igual al anterior
+
+#### GET /api/v1/catalogs/business-lines
+
+- **Descripción**: Retorna el catálogo de giros/líneas de negocio obtenido de `plataforma-core-ohs`
+- **Auth requerida**: sí (JWT)
+- **Response 200**:
+  ```json
+  [
+    { "id": "BL-001", "descripcion": "Comercio al por menor", "claveIncendio": "CM", "activo": true }
+  ]
+  ```
+- **Response 503**: igual al anterior
+
+### Diseño Frontend
+
+No aplica a esta spec — la integración con el frontend de Next.js es responsabilidad de FT-007 (Integración de Servicios). Esta spec cubre únicamente el backend Java.
+
+### Arquitectura y Dependencias
+
+- **Módulo**: `plataformas-danos-back` (Java 21 / Spring Boot 4.0.5)
+- **Archivos nuevos**:
+  - `model/dto/SubscriberDto.java`
+  - `model/dto/AgentDto.java`
+  - `model/dto/BusinessLineDto.java`
+  - `client/CatalogsClient.java` — interfaz del cliente HTTP
+  - `client/CatalogsClientImpl.java` — implementación con WebClient/RestTemplate
+  - `service/CatalogsService.java` — interfaz del servicio
+  - `service/CatalogsServiceImpl.java` — orquesta cliente + mapeo + resiliencia
+  - `controller/CatalogsController.java` — endpoints `/api/v1/catalogs/*`
+  - `config/CatalogsClientConfig.java` — bean WebClient con URL base
+  - `config/Resilience4jCatalogsConfig.java` — configuración de retry
+- **Dependencias adicionales en `pom.xml`**:
+  - `spring-boot-starter-webflux` (WebClient) o `spring-boot-starter-web` con `RestTemplate`
+  - `resilience4j-spring-boot3` (ya debería estar disponible como parte del stack aprobado)
+- **Configuración externalizada en `application.yml`**:
+  ```yaml
+  plataforma-core-ohs:
+    url: ${PLATAFORMA_CORE_OHS_URL:http://localhost:3001}
+    timeout-ms: 5000
+    retry:
+      max-attempts: 3
+      initial-delay-ms: 1000
+      multiplier: 2.0
+      max-delay-ms: 8000
+  ```
+- **Servicios externos consumidos**:
+  - `GET {plataforma-core-ohs.url}/v1/subscribers`
+  - `GET {plataforma-core-ohs.url}/v1/agents`
+  - `GET {plataforma-core-ohs.url}/v1/business-lines`
+
+### Notas de Implementación
+
+- Usar `RestTemplate` con `SimpleClientHttpRequestFactory` en lugar de WebFlux para mantener el stack blocking consistente con Spring MVC.
+- La lógica de retry se implementa con `@Retryable` de `spring-retry` (alternativa simple) o con `Retry` de Resilience4j. Priorizar Resilience4j 2.3.0 (ya en el stack aprobado).
+- El mapeo es directo (campos del DTO externo = campos del DTO interno en este caso) ya que el mock usa los mismos nombres. Si el servicio real cambiara, solo se modifica `CatalogsClientImpl`.
+- Los errores HTTP `5xx` del servicio externo se traducen a `503 SERVICE_UNAVAILABLE` en la respuesta al frontend. Los `4xx` se propagan como `502 BAD_GATEWAY` con log de ERROR.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable para todos los agentes. Marcar cada ítem (`[x]`) al completarlo.
+> El Orchestrator monitorea este checklist para determinar el progreso.
+
+### Backend
+
+#### Implementación
+
+- [ ] Crear `model/dto/SubscriberDto.java` — campos `id`, `nombre`, `clave`, `activo` (Lombok `@Data`)
+- [ ] Crear `model/dto/AgentDto.java` — campos `id`, `nombre`, `clave`, `activo`
+- [ ] Crear `model/dto/BusinessLineDto.java` — campos `id`, `descripcion`, `claveIncendio`, `activo`
+- [ ] Crear `config/CatalogsClientConfig.java` — bean `RestTemplate` con `baseUrl` y `connectionTimeout`
+- [ ] Crear `config/Resilience4jCatalogsConfig.java` — configuración `RetryConfig` (3 intentos, backoff exponencial, solo errores recuperables)
+- [ ] Crear `client/CatalogsClient.java` (interfaz) + `CatalogsClientImpl.java` — llamadas HTTP a `/v1/subscribers`, `/v1/agents`, `/v1/business-lines`
+- [ ] Crear `service/CatalogsService.java` (interfaz) + `CatalogsServiceImpl.java` — orquesta cliente + mapeo + retry + manejo de errores
+- [ ] Crear `controller/CatalogsController.java` — `GET /api/v1/catalogs/subscribers`, `GET /api/v1/catalogs/agents`, `GET /api/v1/catalogs/business-lines`
+- [ ] Agregar `PLATAFORMA_CORE_OHS_URL` a `application.yml` y `.env.example`
+- [ ] Registrar `CatalogsController` en el contexto de Spring (autowired vía `@RestController`)
+
+#### Tests Backend
+
+- [ ] `test_get_subscribers_returns_200_with_list` — happy path, lista no vacía
+- [ ] `test_get_subscribers_empty_list_returns_200` — lista vacía es respuesta válida
+- [ ] `test_get_subscribers_service_unavailable_returns_503` — fallo del servicio externo tras reintentos
+- [ ] `test_get_agents_returns_200_with_list` — happy path agentes
+- [ ] `test_get_agents_service_unavailable_returns_503` — fallo agentes
+- [ ] `test_get_business_lines_returns_200_with_list` — happy path giros
+- [ ] `test_get_business_lines_service_unavailable_returns_503` — fallo giros
+- [ ] `test_retry_succeeds_on_second_attempt` — reintento exitoso en segundo intento
+- [ ] `test_retry_exhausted_throws_service_exception` — reintentos agotados → excepción
+- [ ] `test_4xx_error_not_retried` — HTTP 400/404 NO activan reintentos
+- [ ] `test_mapping_drops_invalid_record_missing_id` — registro sin `id` se descarta (log WARNING)
+- [ ] `test_catalogs_service_impl_maps_all_fields` — transformación completa de campos
+
+### Frontend
+
+No aplica a esta spec.
+
+### QA
+
+- [ ] Ejecutar skill `/gherkin-case-generator` → criterios CRITERIO-1.1 al 6.3
+- [ ] Ejecutar skill `/risk-identifier` → clasificar riesgo de dependencia crítica con servicio externo
+- [ ] Verificar cobertura de tests ≥ 80% en `service/`, `client/`, `controller/`
+- [ ] Prueba de integración manual: levantar `plataforma-core-ohs` (mock) y hacer GET /api/v1/catalogs/subscribers → respuesta válida
+- [ ] Prueba de resiliencia manual: apagar mock → llamar endpoint → verificar 503 + log CRITICAL
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClient.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClient.java
@@ -1,0 +1,13 @@
+package com.plataformas_danos_back.client;
+
+import com.plataformas_danos_back.model.dto.AgentDto;
+import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.SubscriberDto;
+
+import java.util.List;
+
+public interface CatalogsClient {
+    List<SubscriberDto> getSubscribers();
+    List<AgentDto> getAgents();
+    List<BusinessLineDto> getBusinessLines();
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClientImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClientImpl.java
@@ -1,0 +1,62 @@
+package com.plataformas_danos_back.client;
+
+import com.plataformas_danos_back.model.dto.AgentDto;
+import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.SubscriberDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class CatalogsClientImpl implements CatalogsClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${plataforma-core-ohs.url:http://localhost:3001}")
+    private String baseUrl;
+
+    public CatalogsClientImpl(@Qualifier("catalogsRestTemplate") RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public List<SubscriberDto> getSubscribers() {
+        String url = baseUrl + "/v1/subscribers";
+        log.debug("Calling external service: GET {}", url);
+        ResponseEntity<List<SubscriberDto>> response = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<>() {}
+        );
+        return response.getBody();
+    }
+
+    @Override
+    public List<AgentDto> getAgents() {
+        String url = baseUrl + "/v1/agents";
+        log.debug("Calling external service: GET {}", url);
+        ResponseEntity<List<AgentDto>> response = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<>() {}
+        );
+        return response.getBody();
+    }
+
+    @Override
+    public List<BusinessLineDto> getBusinessLines() {
+        String url = baseUrl + "/v1/business-lines";
+        log.debug("Calling external service: GET {}", url);
+        ResponseEntity<List<BusinessLineDto>> response = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<>() {}
+        );
+        return response.getBody();
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/CatalogsClientConfig.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/CatalogsClientConfig.java
@@ -1,0 +1,22 @@
+package com.plataformas_danos_back.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class CatalogsClientConfig {
+
+    @Value("${plataforma-core-ohs.timeout-ms:5000}")
+    private int timeoutMs;
+
+    @Bean("catalogsRestTemplate")
+    public RestTemplate catalogsRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(timeoutMs);
+        factory.setReadTimeout(timeoutMs);
+        return new RestTemplate(factory);
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/SecurityConfig.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.plataformas_danos_back.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth ->
+                        auth.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/controller/CatalogsController.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/controller/CatalogsController.java
@@ -1,0 +1,36 @@
+package com.plataformas_danos_back.controller;
+
+import com.plataformas_danos_back.model.dto.AgentDto;
+import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.SubscriberDto;
+import com.plataformas_danos_back.service.CatalogsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/catalogs")
+public class CatalogsController {
+
+    private final CatalogsService catalogsService;
+
+    @GetMapping("/subscribers")
+    public ResponseEntity<List<SubscriberDto>> getSubscribers() {
+        return ResponseEntity.ok(catalogsService.getSubscribers());
+    }
+
+    @GetMapping("/agents")
+    public ResponseEntity<List<AgentDto>> getAgents() {
+        return ResponseEntity.ok(catalogsService.getAgents());
+    }
+
+    @GetMapping("/business-lines")
+    public ResponseEntity<List<BusinessLineDto>> getBusinessLines() {
+        return ResponseEntity.ok(catalogsService.getBusinessLines());
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/CatalogServiceUnavailableException.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/CatalogServiceUnavailableException.java
@@ -1,0 +1,12 @@
+package com.plataformas_danos_back.exception;
+
+public class CatalogServiceUnavailableException extends RuntimeException {
+
+    public CatalogServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    public CatalogServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/GlobalExceptionHandler.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/GlobalExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.plataformas_danos_back.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CatalogServiceUnavailableException.class)
+    public ResponseEntity<Map<String, String>> handleCatalogUnavailable(CatalogServiceUnavailableException ex) {
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(Map.of("message", ex.getMessage(), "code", "CATALOG_SERVICE_UNAVAILABLE"));
+    }
+
+    @ExceptionHandler(HttpClientErrorException.class)
+    public ResponseEntity<Map<String, String>> handleHttpClientError(HttpClientErrorException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                .body(Map.of(
+                        "message", "El servicio externo retornó un error: " + ex.getStatusCode(),
+                        "code", "EXTERNAL_CLIENT_ERROR"
+                ));
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/AgentDto.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/AgentDto.java
@@ -1,0 +1,15 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AgentDto {
+    private String id;
+    private String nombre;
+    private String clave;
+    private Boolean activo;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/BusinessLineDto.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/BusinessLineDto.java
@@ -1,0 +1,15 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BusinessLineDto {
+    private String id;
+    private String descripcion;
+    private String claveIncendio;
+    private Boolean activo;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/SubscriberDto.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/SubscriberDto.java
@@ -1,0 +1,15 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubscriberDto {
+    private String id;
+    private String nombre;
+    private String clave;
+    private Boolean activo;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsService.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsService.java
@@ -1,0 +1,13 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.dto.AgentDto;
+import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.SubscriberDto;
+
+import java.util.List;
+
+public interface CatalogsService {
+    List<SubscriberDto> getSubscribers();
+    List<AgentDto> getAgents();
+    List<BusinessLineDto> getBusinessLines();
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsServiceImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsServiceImpl.java
@@ -1,0 +1,105 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.client.CatalogsClient;
+import com.plataformas_danos_back.exception.CatalogServiceUnavailableException;
+import com.plataformas_danos_back.model.dto.AgentDto;
+import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.SubscriberDto;
+import io.github.resilience4j.retry.annotation.Retry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CatalogsServiceImpl implements CatalogsService {
+
+    private final CatalogsClient catalogsClient;
+
+    @Override
+    @Retry(name = "plataforma-core-ohs", fallbackMethod = "subscribersFallback")
+    public List<SubscriberDto> getSubscribers() {
+        return filterValidSubscribers(catalogsClient.getSubscribers());
+    }
+
+    @Override
+    @Retry(name = "plataforma-core-ohs", fallbackMethod = "agentsFallback")
+    public List<AgentDto> getAgents() {
+        return filterValidAgents(catalogsClient.getAgents());
+    }
+
+    @Override
+    @Retry(name = "plataforma-core-ohs", fallbackMethod = "businessLinesFallback")
+    public List<BusinessLineDto> getBusinessLines() {
+        return filterValidBusinessLines(catalogsClient.getBusinessLines());
+    }
+
+    public List<SubscriberDto> subscribersFallback(Exception ex) {
+        log.error("CRITICAL: Catalog service unavailable after retries — subscribers. Error: {}", ex.getMessage());
+        throw new CatalogServiceUnavailableException("Servicio de catálogos no disponible", ex);
+    }
+
+    public List<AgentDto> agentsFallback(Exception ex) {
+        log.error("CRITICAL: Catalog service unavailable after retries — agents. Error: {}", ex.getMessage());
+        throw new CatalogServiceUnavailableException("Servicio de catálogos no disponible", ex);
+    }
+
+    public List<BusinessLineDto> businessLinesFallback(Exception ex) {
+        log.error("CRITICAL: Catalog service unavailable after retries — business-lines. Error: {}", ex.getMessage());
+        throw new CatalogServiceUnavailableException("Servicio de catálogos no disponible", ex);
+    }
+
+    private List<SubscriberDto> filterValidSubscribers(List<SubscriberDto> list) {
+        if (list == null) return List.of();
+        return list.stream()
+                .filter(s -> {
+                    if (s.getId() == null || s.getId().isBlank()) {
+                        log.warn("Subscriber record dropped: missing required field 'id'");
+                        return false;
+                    }
+                    if (s.getNombre() == null || s.getNombre().isBlank()) {
+                        log.warn("Subscriber record dropped: missing required field 'nombre', id={}", s.getId());
+                        return false;
+                    }
+                    return true;
+                })
+                .toList();
+    }
+
+    private List<AgentDto> filterValidAgents(List<AgentDto> list) {
+        if (list == null) return List.of();
+        return list.stream()
+                .filter(a -> {
+                    if (a.getId() == null || a.getId().isBlank()) {
+                        log.warn("Agent record dropped: missing required field 'id'");
+                        return false;
+                    }
+                    if (a.getNombre() == null || a.getNombre().isBlank()) {
+                        log.warn("Agent record dropped: missing required field 'nombre', id={}", a.getId());
+                        return false;
+                    }
+                    return true;
+                })
+                .toList();
+    }
+
+    private List<BusinessLineDto> filterValidBusinessLines(List<BusinessLineDto> list) {
+        if (list == null) return List.of();
+        return list.stream()
+                .filter(b -> {
+                    if (b.getId() == null || b.getId().isBlank()) {
+                        log.warn("BusinessLine record dropped: missing required field 'id'");
+                        return false;
+                    }
+                    if (b.getDescripcion() == null || b.getDescripcion().isBlank()) {
+                        log.warn("BusinessLine record dropped: missing required field 'descripcion', id={}", b.getId());
+                        return false;
+                    }
+                    return true;
+                })
+                .toList();
+    }
+}

--- a/plataformas-danos-back/src/main/resources/application.yaml
+++ b/plataformas-danos-back/src/main/resources/application.yaml
@@ -23,6 +23,10 @@ jwt:
   secret: ${JWT_SECRET:changeme-use-env-var-in-production}
   expiration-ms: ${JWT_EXPIRATION_MS:86400000}
 
+plataforma-core-ohs:
+  url: ${PLATAFORMA_CORE_OHS_URL:http://localhost:3001}
+  timeout-ms: ${PLATAFORMA_CORE_OHS_TIMEOUT_MS:5000}
+
 resilience4j:
   circuitbreaker:
     instances:
@@ -34,4 +38,10 @@ resilience4j:
     instances:
       plataforma-core-ohs:
         max-attempts: 3
-        wait-duration: 500ms
+        wait-duration: 1000ms
+        exponential-backoff-multiplier: 2.0
+        retry-exceptions:
+          - org.springframework.web.client.HttpServerErrorException
+          - org.springframework.web.client.ResourceAccessException
+        ignore-exceptions:
+          - org.springframework.web.client.HttpClientErrorException

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/controller/CatalogsControllerTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/controller/CatalogsControllerTest.java
@@ -1,0 +1,133 @@
+package com.plataformas_danos_back.controller;
+
+import com.plataformas_danos_back.exception.CatalogServiceUnavailableException;
+import com.plataformas_danos_back.model.dto.AgentDto;
+import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.SubscriberDto;
+import com.plataformas_danos_back.service.CatalogsService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CatalogsControllerTest {
+
+    @Mock
+    private CatalogsService catalogsService;
+
+    @InjectMocks
+    private CatalogsController controller;
+
+    // ── Subscribers ──────────────────────────────────────────────────────────
+
+    @Test
+    void getSubscribers_serviceReturnsData_returns200WithList() {
+        // GIVEN
+        var subscribers = List.of(
+                new SubscriberDto("SUB-001", "Empresa ABC S.A. de C.V.", "ABC", true),
+                new SubscriberDto("SUB-002", "Corporativo XYZ", "XYZ", true)
+        );
+        when(catalogsService.getSubscribers()).thenReturn(subscribers);
+
+        // WHEN
+        var response = controller.getSubscribers();
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody().get(0).getId()).isEqualTo("SUB-001");
+        assertThat(response.getBody().get(0).getNombre()).isEqualTo("Empresa ABC S.A. de C.V.");
+    }
+
+    @Test
+    void getSubscribers_emptyList_returns200WithEmptyBody() {
+        // GIVEN
+        when(catalogsService.getSubscribers()).thenReturn(List.of());
+
+        // WHEN
+        var response = controller.getSubscribers();
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isEmpty();
+    }
+
+    @Test
+    void getSubscribers_serviceUnavailable_propagatesException() {
+        // GIVEN — GlobalExceptionHandler transforma la excepción en 503 en el contexto HTTP;
+        // aquí verificamos que el controlador no la suprime
+        when(catalogsService.getSubscribers())
+                .thenThrow(new CatalogServiceUnavailableException("Servicio de catálogos no disponible"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> controller.getSubscribers())
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
+    }
+
+    // ── Agents ──────────────────────────────────────────────────────────────
+
+    @Test
+    void getAgents_serviceReturnsData_returns200WithList() {
+        // GIVEN
+        var agents = List.of(new AgentDto("AGT-001", "Juan Pérez García", "JPG", true));
+        when(catalogsService.getAgents()).thenReturn(agents);
+
+        // WHEN
+        var response = controller.getAgents();
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).getId()).isEqualTo("AGT-001");
+    }
+
+    @Test
+    void getAgents_serviceUnavailable_propagatesException() {
+        // GIVEN
+        when(catalogsService.getAgents())
+                .thenThrow(new CatalogServiceUnavailableException("Servicio de catálogos no disponible"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> controller.getAgents())
+                .isInstanceOf(CatalogServiceUnavailableException.class);
+    }
+
+    // ── Business Lines ───────────────────────────────────────────────────────
+
+    @Test
+    void getBusinessLines_serviceReturnsData_returns200WithList() {
+        // GIVEN
+        var lines = List.of(new BusinessLineDto("BL-001", "Comercio al por menor", "CM", true));
+        when(catalogsService.getBusinessLines()).thenReturn(lines);
+
+        // WHEN
+        var response = controller.getBusinessLines();
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).getId()).isEqualTo("BL-001");
+        assertThat(response.getBody().get(0).getDescripcion()).isEqualTo("Comercio al por menor");
+    }
+
+    @Test
+    void getBusinessLines_serviceUnavailable_propagatesException() {
+        // GIVEN
+        when(catalogsService.getBusinessLines())
+                .thenThrow(new CatalogServiceUnavailableException("Servicio de catálogos no disponible"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> controller.getBusinessLines())
+                .isInstanceOf(CatalogServiceUnavailableException.class);
+    }
+}

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/CatalogsServiceImplTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/CatalogsServiceImplTest.java
@@ -1,0 +1,198 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.client.CatalogsClient;
+import com.plataformas_danos_back.exception.CatalogServiceUnavailableException;
+import com.plataformas_danos_back.model.dto.AgentDto;
+import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.SubscriberDto;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CatalogsServiceImplTest {
+
+    @Mock
+    private CatalogsClient catalogsClient;
+
+    @InjectMocks
+    private CatalogsServiceImpl service;
+
+    // ── Subscribers ──────────────────────────────────────────────────────────
+
+    @Test
+    void getSubscribers_validList_returns200WithList() {
+        // GIVEN
+        var subscriber = new SubscriberDto("SUB-001", "Empresa ABC S.A. de C.V.", "ABC", true);
+        when(catalogsClient.getSubscribers()).thenReturn(List.of(subscriber));
+
+        // WHEN
+        var result = service.getSubscribers();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("SUB-001");
+    }
+
+    @Test
+    void getSubscribers_emptyList_returnsEmptyList() {
+        // GIVEN
+        when(catalogsClient.getSubscribers()).thenReturn(List.of());
+
+        // WHEN
+        var result = service.getSubscribers();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void subscribersFallback_whenCalled_throwsCatalogServiceUnavailableException() {
+        // GIVEN
+        var cause = new RuntimeException("Connection refused");
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> service.subscribersFallback(cause))
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
+    }
+
+    @Test
+    void getSubscribers_recordMissingId_isDropped() {
+        // GIVEN
+        var valid = new SubscriberDto("SUB-001", "Empresa ABC", "ABC", true);
+        var invalidId = new SubscriberDto(null, "Sin Identificador", "X", true);
+        when(catalogsClient.getSubscribers()).thenReturn(List.of(valid, invalidId));
+
+        // WHEN
+        var result = service.getSubscribers();
+
+        // THEN — solo el registro válido se retorna
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("SUB-001");
+    }
+
+    @Test
+    void getSubscribers_mapsAllFields() {
+        // GIVEN
+        var subscriber = new SubscriberDto("SUB-001", "Empresa ABC S.A.", "ABC", true);
+        when(catalogsClient.getSubscribers()).thenReturn(List.of(subscriber));
+
+        // WHEN
+        var result = service.getSubscribers();
+
+        // THEN
+        var dto = result.get(0);
+        assertThat(dto.getId()).isEqualTo("SUB-001");
+        assertThat(dto.getNombre()).isEqualTo("Empresa ABC S.A.");
+        assertThat(dto.getClave()).isEqualTo("ABC");
+        assertThat(dto.getActivo()).isTrue();
+    }
+
+    @Test
+    void getSubscribers_clientThrowsHttpClientErrorException_exceptionPropagates() {
+        // GIVEN — 4xx errors are in ignore-exceptions; without AOP proxy they propagate directly
+        when(catalogsClient.getSubscribers())
+                .thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+
+        // WHEN / THEN — error 4xx no debe ser envuelto en CatalogServiceUnavailableException
+        assertThatThrownBy(() -> service.getSubscribers())
+                .isInstanceOf(HttpClientErrorException.class);
+    }
+
+    // ── Agents ──────────────────────────────────────────────────────────────
+
+    @Test
+    void getAgents_validList_returns200WithList() {
+        // GIVEN
+        var agent = new AgentDto("AGT-001", "Juan Pérez García", "JPG", true);
+        when(catalogsClient.getAgents()).thenReturn(List.of(agent));
+
+        // WHEN
+        var result = service.getAgents();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("AGT-001");
+        assertThat(result.get(0).getNombre()).isEqualTo("Juan Pérez García");
+    }
+
+    @Test
+    void agentsFallback_whenCalled_throwsCatalogServiceUnavailableException() {
+        // GIVEN
+        var cause = new RuntimeException("Timeout");
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> service.agentsFallback(cause))
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
+    }
+
+    @Test
+    void getAgents_recordMissingNombre_isDropped() {
+        // GIVEN
+        var valid = new AgentDto("AGT-001", "Juan Pérez", "JPG", true);
+        var invalidNombre = new AgentDto("AGT-002", "", "X", true);
+        when(catalogsClient.getAgents()).thenReturn(List.of(valid, invalidNombre));
+
+        // WHEN
+        var result = service.getAgents();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("AGT-001");
+    }
+
+    // ── Business Lines ───────────────────────────────────────────────────────
+
+    @Test
+    void getBusinessLines_validList_returns200WithList() {
+        // GIVEN
+        var bl = new BusinessLineDto("BL-001", "Comercio al por menor", "CM", true);
+        when(catalogsClient.getBusinessLines()).thenReturn(List.of(bl));
+
+        // WHEN
+        var result = service.getBusinessLines();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("BL-001");
+        assertThat(result.get(0).getDescripcion()).isEqualTo("Comercio al por menor");
+    }
+
+    @Test
+    void businessLinesFallback_whenCalled_throwsCatalogServiceUnavailableException() {
+        // GIVEN
+        var cause = new RuntimeException("Service down");
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> service.businessLinesFallback(cause))
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
+    }
+
+    @Test
+    void getBusinessLines_recordMissingId_isDropped() {
+        // GIVEN
+        var valid = new BusinessLineDto("BL-001", "Comercio", "CM", true);
+        var invalidId = new BusinessLineDto("  ", "Sin ID", "X", true);
+        when(catalogsClient.getBusinessLines()).thenReturn(List.of(valid, invalidId));
+
+        // WHEN
+        var result = service.getBusinessLines();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("BL-001");
+    }
+}


### PR DESCRIPTION
## Implementación de consumo de catálogos básicos con resiliencia

* Se exponen endpoints GET /api/v1/catalogs/* para suscriptores, agentes y giros
* Se implementa cliente HTTP (RestTemplate) hacia plataforma-core-ohs con URL configurable
* Se integra lógica de resiliencia con reintentos y backoff exponencial ante errores 5xx y de red
* Se realiza mapeo a DTOs internos desacoplando el contrato externo
* Manejo de errores estandarizado (503 CATALOG_SERVICE_UNAVAILABLE) y logging por nivel
* Se agregan tests para flujos exitosos, listas vacías, reintentos, errores y validación de mapeo