### PR TITLE
EP-003 FT-017 Core | Clasificacion riesgo

### DIFF
--- a/.github/specs/ep-003-ft-017-core-clasificacion-riesgo.spec.md
+++ b/.github/specs/ep-003-ft-017-core-clasificacion-riesgo.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-005
-status: APPROVED
+status: IN_PROGRESS
 feature: ep-003-ft-017-core-clasificacion-riesgo
 created: 2026-04-27
 updated: 2026-04-27
@@ -317,14 +317,14 @@ No aplica a esta spec — la integración con el frontend de Next.js es responsa
 
 #### Implementación
 
-- [ ] Crear `model/dto/RiskClassificationDto.java` — campos `id`, `nombre`, `descripcion` (Lombok `@Data`)
-- [ ] Crear `model/dto/GuaranteeDto.java` — campos `id`, `nombre`, `claveIncendio`, `tarifable` (Lombok `@Data`)
-- [ ] Actualizar `client/CatalogsClient.java` — agregar `getRiskClassifications()` y `getGuarantees()`
-- [ ] Actualizar `client/CatalogsClientImpl.java` — implementar llamadas a `/v1/catalogs/risk-classification` y `/v1/catalogs/guarantees` con `ParameterizedTypeReference`
-- [ ] Actualizar `service/CatalogsService.java` — agregar `getRiskClassifications()` y `getGuarantees()`
-- [ ] Actualizar `service/CatalogsServiceImpl.java` — implementar con `@Retry(name="plataforma-core-ohs", fallbackMethod=...)`, filtros de registros inválidos, y fallbacks `riskClassificationsFallback` y `guaranteesFallback`
-- [ ] Actualizar `controller/CatalogsController.java` — agregar `GET /risk-classifications` y `GET /guarantees`
-- [ ] Verificar que `application.yaml` ya tiene la instancia retry `plataforma-core-ohs` configurada (no requiere cambios)
+- [x] Crear `model/dto/RiskClassificationDto.java` — campos `id`, `nombre`, `descripcion` (Lombok `@Data`)
+- [x] Crear `model/dto/GuaranteeDto.java` — campos `id`, `nombre`, `claveIncendio`, `tarifable` (Lombok `@Data`)
+- [x] Actualizar `client/CatalogsClient.java` — agregar `getRiskClassifications()` y `getGuarantees()`
+- [x] Actualizar `client/CatalogsClientImpl.java` — implementar llamadas a `/v1/catalogs/risk-classification` y `/v1/catalogs/guarantees` con `ParameterizedTypeReference`
+- [x] Actualizar `service/CatalogsService.java` — agregar `getRiskClassifications()` y `getGuarantees()`
+- [x] Actualizar `service/CatalogsServiceImpl.java` — implementar con `@Retry(name="plataforma-core-ohs", fallbackMethod=...)`, filtros de registros inválidos, y fallbacks `riskClassificationsFallback` y `guaranteesFallback`
+- [x] Actualizar `controller/CatalogsController.java` — agregar `GET /risk-classifications` y `GET /guarantees`
+- [x] Verificar que `application.yaml` ya tiene la instancia retry `plataforma-core-ohs` configurada (no requiere cambios)
 
 #### Tests Backend
 

--- a/.github/specs/ep-003-ft-017-core-clasificacion-riesgo.spec.md
+++ b/.github/specs/ep-003-ft-017-core-clasificacion-riesgo.spec.md
@@ -1,6 +1,6 @@
 ---
 id: SPEC-005
-status: IN_PROGRESS
+status: IMPLEMENTED
 feature: ep-003-ft-017-core-clasificacion-riesgo
 created: 2026-04-27
 updated: 2026-04-27
@@ -328,20 +328,20 @@ No aplica a esta spec — la integración con el frontend de Next.js es responsa
 
 #### Tests Backend
 
-- [ ] `getRiskClassifications_validList_returns200WithList` — happy path, lista con datos
-- [ ] `getRiskClassifications_emptyList_returnsEmptyList` — lista vacía retornada correctamente
-- [ ] `riskClassificationsFallback_whenCalled_throwsCatalogServiceUnavailableException` — fallback directo
-- [ ] `getRiskClassifications_recordMissingId_isDropped` — registro sin id descartado + log.warn
-- [ ] `getRiskClassifications_mapsAllFields` — id, nombre, descripcion preservados
-- [ ] `getGuarantees_validList_returns200WithList` — happy path, lista con datos
-- [ ] `getGuarantees_emptyList_returnsEmptyList` — lista vacía retornada correctamente
-- [ ] `guaranteesFallback_whenCalled_throwsCatalogServiceUnavailableException` — fallback directo
-- [ ] `getGuarantees_recordMissingNombre_isDropped` — registro con nombre vacío descartado + log.warn
-- [ ] `getGuarantees_mapsAllFields` — id, nombre, claveIncendio, tarifable preservados
-- [ ] `getCatalogsController_getRiskClassifications_returns200WithList` — controller delega al service, retorna 200
-- [ ] `getCatalogsController_getGuarantees_returns200WithList` — controller delega al service, retorna 200
-- [ ] `getCatalogsController_getRiskClassifications_serviceUnavailable_propagatesException` — excepción propagada
-- [ ] `getCatalogsController_getGuarantees_serviceUnavailable_propagatesException` — excepción propagada
+- [x] `getRiskClassifications_validList_returns200WithList` — happy path, lista con datos
+- [x] `getRiskClassifications_emptyList_returnsEmptyList` — lista vacía retornada correctamente
+- [x] `riskClassificationsFallback_whenCalled_throwsCatalogServiceUnavailableException` — fallback directo
+- [x] `getRiskClassifications_recordMissingId_isDropped` — registro sin id descartado + log.warn
+- [x] `getRiskClassifications_mapsAllFields` — id, nombre, descripcion preservados
+- [x] `getGuarantees_validList_returns200WithList` — happy path, lista con datos
+- [x] `getGuarantees_emptyList_returnsEmptyList` — lista vacía retornada correctamente
+- [x] `guaranteesFallback_whenCalled_throwsCatalogServiceUnavailableException` — fallback directo
+- [x] `getGuarantees_recordMissingNombre_isDropped` — registro con nombre vacío descartado + log.warn
+- [x] `getGuarantees_mapsAllFields` — id, nombre, claveIncendio, tarifable preservados
+- [x] `getCatalogsController_getRiskClassifications_returns200WithList` — controller delega al service, retorna 200
+- [x] `getCatalogsController_getGuarantees_returns200WithList` — controller delega al service, retorna 200
+- [x] `getCatalogsController_getRiskClassifications_serviceUnavailable_propagatesException` — excepción propagada
+- [x] `getCatalogsController_getGuarantees_serviceUnavailable_propagatesException` — excepción propagada
 
 ### Frontend
 

--- a/.github/specs/ep-003-ft-017-core-clasificacion-riesgo.spec.md
+++ b/.github/specs/ep-003-ft-017-core-clasificacion-riesgo.spec.md
@@ -1,0 +1,358 @@
+---
+id: SPEC-005
+status: APPROVED
+feature: ep-003-ft-017-core-clasificacion-riesgo
+created: 2026-04-27
+updated: 2026-04-27
+author: spec-generator
+version: "1.0"
+related-specs:
+  - SPEC-001
+  - SPEC-003
+---
+
+# Spec: FT-017 — Integración de Catálogos de Clasificación de Riesgo y Garantías
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+Esta feature extiende en `plataformas-danos-back` (Java 21 / Spring Boot) la capa de catálogos existente (SPEC-003) para integrar dos nuevos catálogos provenientes de `plataforma-core-ohs`: clasificación de riesgo y garantías. Sigue el mismo patrón de cliente HTTP, filtrado de registros inválidos, resiliencia Resilience4j y exposición REST ya establecido en FT-015, con una única diferencia: la adición de métodos a los artefactos existentes en lugar de crear nuevos.
+
+### Requerimiento de Negocio
+
+El cotizador de seguros de daños necesita catálogos de clasificación de riesgo y garantías para que el usuario pueda configurar coberturas con opciones actualizadas y consistentes con las políticas de suscripción. Esta información proviene exclusivamente de `plataforma-core-ohs`. La disponibilidad de ambos catálogos es prerequisito para la configuración de coberturas (HU-011) y el cálculo de primas (HU-015).
+
+### Historias de Usuario
+
+#### HU-01: Recuperar catálogo de clasificación de riesgo (HU-077)
+
+```
+Como:        Sistema (cotizador — plataformas-danos-back)
+Quiero:      Consultar el catálogo de clasificación de riesgo desde plataforma-core-ohs
+Para:        Ofrecer opciones actualizadas en la definición de coberturas de la cotización
+
+Prioridad:   Alta
+Estimación:  M (3 story points)
+Dependencias: SPEC-001 (mock server operativo), SPEC-003 (patrón cliente HTTP establecido)
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-01
+
+**Happy Path**
+```gherkin
+CRITERIO-1.1: Consulta exitosa del catálogo de clasificación de riesgo
+  Dado que:  plataforma-core-ohs está activo y tiene clasificaciones de riesgo en el catálogo
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/risk-classifications
+  Entonces:  recibe HTTP 200 con una lista de objetos
+             [{ "id": "RC-001", "nombre": "Riesgo Bajo", "descripcion": "..." }, ...]
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-1.2: Catálogo de clasificación de riesgo vacío
+  Dado que:  plataforma-core-ohs devuelve lista vacía
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/risk-classifications
+  Entonces:  recibe HTTP 200 con lista vacía []
+```
+
+**Error Path**
+```gherkin
+CRITERIO-1.3: Servicio externo no disponible tras reintentos
+  Dado que:  plataforma-core-ohs no responde después de 3 intentos
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/risk-classifications
+  Entonces:  recibe HTTP 503 con { "message": "Servicio de catálogos no disponible",
+             "code": "CATALOG_SERVICE_UNAVAILABLE" }
+```
+
+---
+
+#### HU-02: Recuperar catálogo de garantías (HU-078)
+
+```
+Como:        Sistema (cotizador — plataformas-danos-back)
+Quiero:      Consultar el catálogo de garantías desde plataforma-core-ohs
+Para:        Ofrecer opciones de garantías completas y actualizadas en la configuración de coberturas
+
+Prioridad:   Alta
+Estimación:  M (3 story points)
+Dependencias: SPEC-001, SPEC-003, HU-01
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-02
+
+**Happy Path**
+```gherkin
+CRITERIO-2.1: Consulta exitosa del catálogo de garantías
+  Dado que:  plataforma-core-ohs está activo y tiene garantías en el catálogo
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/guarantees
+  Entonces:  recibe HTTP 200 con una lista de objetos
+             [{ "id": "GUA-001", "nombre": "Robo con Violencia",
+                "claveIncendio": "RV", "tarifable": true }, ...]
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-2.2: Catálogo de garantías vacío
+  Dado que:  plataforma-core-ohs devuelve lista vacía
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/guarantees
+  Entonces:  recibe HTTP 200 con lista vacía []
+```
+
+**Error Path**
+```gherkin
+CRITERIO-2.3: Servicio externo no disponible tras reintentos
+  Dado que:  plataforma-core-ohs no responde después de 3 intentos
+  Cuando:    el cotizador llama a GET /api/v1/catalogs/guarantees
+  Entonces:  recibe HTTP 503 con { "message": "Servicio de catálogos no disponible",
+             "code": "CATALOG_SERVICE_UNAVAILABLE" }
+```
+
+---
+
+#### HU-03: Mapear y filtrar registros inválidos (HU-079)
+
+```
+Como:        Sistema (cotizador)
+Quiero:      Filtrar registros con campos obligatorios ausentes y mapear la respuesta al modelo interno
+Para:        Garantizar que solo datos íntegros llegan a la capa de presentación
+
+Prioridad:   Alta
+Estimación:  S (2 story points)
+Dependencias: HU-01, HU-02
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-03
+
+**Happy Path**
+```gherkin
+CRITERIO-3.1: Todos los campos de clasificación de riesgo se mapean correctamente
+  Dado que:  plataforma-core-ohs devuelve una lista con registros completos
+  Cuando:    el servicio procesa la respuesta de clasificación de riesgo
+  Entonces:  todos los campos (id, nombre, descripcion) se preservan en el RiskClassificationDto
+```
+
+**Happy Path**
+```gherkin
+CRITERIO-3.2: Todos los campos de garantía se mapean correctamente
+  Dado que:  plataforma-core-ohs devuelve una lista con registros completos
+  Cuando:    el servicio procesa la respuesta de garantías
+  Entonces:  todos los campos (id, nombre, claveIncendio, tarifable) se preservan en el GuaranteeDto
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-3.3: Registro de clasificación de riesgo con id nulo es descartado
+  Dado que:  la respuesta incluye un registro sin id
+  Cuando:    el servicio filtra los registros
+  Entonces:  el registro inválido es descartado y se registra un WARNING en los logs;
+             los registros válidos se retornan normalmente
+```
+
+**Edge Case**
+```gherkin
+CRITERIO-3.4: Registro de garantía con nombre vacío es descartado
+  Dado que:  la respuesta incluye un registro con nombre vacío
+  Cuando:    el servicio filtra los registros
+  Entonces:  el registro inválido es descartado y se registra un WARNING en los logs
+```
+
+---
+
+### Reglas de Negocio
+
+1. **Filtrado de registros inválidos (Clasificación de Riesgo)**: Se descartan registros donde `id` sea null o blank, o donde `nombre` sea null o blank. Se registra un WARNING por cada descarte.
+2. **Filtrado de registros inválidos (Garantías)**: Se descartan registros donde `id` sea null o blank, o donde `nombre` sea null o blank. Se registra un WARNING por cada descarte.
+3. **Fuente única**: Los catálogos de clasificación de riesgo y garantías solo se obtienen de `plataforma-core-ohs`. No se persisten en MongoDB.
+4. **Reintentos**: Máximo 3 intentos con backoff exponencial (1000ms base, ×2). Solo para errores 5xx y de red; errores 4xx no se reintentan. Reutiliza la instancia `plataforma-core-ohs` ya configurada en `application.yaml`.
+5. **Sin autenticación en mock**: La URL base se configura con `PLATAFORMA_CORE_OHS_URL`. El mock no requiere token.
+6. **Extensión de artefactos existentes**: Los nuevos métodos se agregan a `CatalogsClient`, `CatalogsClientImpl`, `CatalogsService` y `CatalogsServiceImpl` existentes. No se crean nuevas clases de servicio/cliente.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Almacén | Cambios | Descripción |
+|---------|---------|---------|-------------|
+| `RiskClassificationDto` | ninguno (solo memoria) | nueva | DTO de clasificación de riesgo |
+| `GuaranteeDto` | ninguno (solo memoria) | nueva | DTO de garantía |
+
+> No se crea ninguna colección MongoDB. Los datos se leen del servicio externo y se retornan directamente.
+
+#### Campos del modelo — `RiskClassificationDto`
+
+| Campo | Tipo | Obligatorio | Validación | Descripción |
+|-------|------|-------------|------------|-------------|
+| `id` | String | sí | non-blank | Identificador de la clasificación |
+| `nombre` | String | sí | non-blank | Nombre descriptivo |
+| `descripcion` | String | sí | max 500 chars | Descripción de la clasificación |
+
+#### Campos del modelo — `GuaranteeDto`
+
+| Campo | Tipo | Obligatorio | Validación | Descripción |
+|-------|------|-------------|------------|-------------|
+| `id` | String | sí | non-blank | Identificador de la garantía |
+| `nombre` | String | sí | max 200 chars | Nombre de la garantía |
+| `claveIncendio` | String | sí | max 50 chars | Clave de incendio asociada |
+| `tarifable` | Boolean | sí | — | Indica si la garantía es tarifable |
+
+#### Índices / Constraints
+
+No aplica — no hay persistencia en MongoDB para estos modelos.
+
+### API Endpoints
+
+#### GET /api/v1/catalogs/risk-classifications
+
+- **Descripción**: Retorna el catálogo completo de clasificaciones de riesgo
+- **Auth requerida**: no (pendiente feature auth — `SecurityConfig` actual es `permitAll()`)
+- **Request Body**: ninguno
+
+- **Response 200**:
+  ```json
+  [
+    { "id": "RC-001", "nombre": "Riesgo Bajo", "descripcion": "Clasificación para riesgos con baja probabilidad de siniestro." },
+    { "id": "RC-002", "nombre": "Riesgo Medio", "descripcion": "Clasificación para riesgos con probabilidad media de siniestro." }
+  ]
+  ```
+
+- **Response 503**: servicio externo no disponible tras reintentos
+  ```json
+  { "message": "Servicio de catálogos no disponible", "code": "CATALOG_SERVICE_UNAVAILABLE" }
+  ```
+
+---
+
+#### GET /api/v1/catalogs/guarantees
+
+- **Descripción**: Retorna el catálogo completo de garantías
+- **Auth requerida**: no (pendiente feature auth — `SecurityConfig` actual es `permitAll()`)
+- **Request Body**: ninguno
+
+- **Response 200**:
+  ```json
+  [
+    { "id": "GUA-001", "nombre": "Robo con Violencia", "claveIncendio": "RV", "tarifable": true },
+    { "id": "GUA-002", "nombre": "Daños por Agua", "claveIncendio": "DA", "tarifable": false }
+  ]
+  ```
+
+- **Response 503**: servicio externo no disponible tras reintentos
+  ```json
+  { "message": "Servicio de catálogos no disponible", "code": "CATALOG_SERVICE_UNAVAILABLE" }
+  ```
+
+### Servicios Externos Consumidos
+
+| Endpoint | Método | Descripción |
+|----------|--------|-------------|
+| `{plataforma-core-ohs.url}/v1/catalogs/risk-classification` | GET | Lista de clasificaciones de riesgo |
+| `{plataforma-core-ohs.url}/v1/catalogs/guarantees` | GET | Lista de garantías |
+
+**Respuesta del mock `risk-classification` (200 OK):**
+```json
+[
+  { "id": "RC-001", "nombre": "Riesgo Bajo", "descripcion": "Clasificación para riesgos con baja probabilidad de siniestro." }
+]
+```
+
+**Respuesta del mock `guarantees` (200 OK):**
+```json
+[
+  { "id": "GUA-001", "nombre": "Robo con Violencia", "claveIncendio": "RV", "tarifable": true }
+]
+```
+
+### Diseño Frontend
+
+No aplica a esta spec — la integración con el frontend de Next.js es responsabilidad de FT-007.
+
+### Arquitectura y Dependencias
+
+- **Módulo**: `plataformas-danos-back` (Java 21 / Spring Boot 4.0.5)
+- **Archivos nuevos**:
+  - `model/dto/RiskClassificationDto.java`
+  - `model/dto/GuaranteeDto.java`
+- **Archivos modificados**:
+  - `client/CatalogsClient.java` — agregar métodos `getRiskClassifications()` y `getGuarantees()`
+  - `client/CatalogsClientImpl.java` — implementar llamadas a `/v1/catalogs/risk-classification` y `/v1/catalogs/guarantees`
+  - `service/CatalogsService.java` — agregar métodos `getRiskClassifications()` y `getGuarantees()`
+  - `service/CatalogsServiceImpl.java` — implementar con `@Retry`, filtros y fallbacks
+  - `controller/CatalogsController.java` — agregar endpoints `GET /api/v1/catalogs/risk-classifications` y `GET /api/v1/catalogs/guarantees`
+- **Reutilización**:
+  - Bean `catalogsRestTemplate` (ya definido en `CatalogsClientConfig`) — misma instancia
+  - Instancia retry `plataforma-core-ohs` en `application.yaml` — mismas reglas ya configuradas
+  - `CatalogServiceUnavailableException` — misma excepción para el fallback
+- **Dependencias ya presentes**: `resilience4j-spring-boot3`, `spring-boot-starter-web`, Lombok
+- **Configuración externalizada**: Solo `plataforma-core-ohs.url` (ya en `application.yaml`)
+
+### Notas de Implementación
+
+- `CatalogsClientImpl` ya usa `@Qualifier("catalogsRestTemplate")` — los nuevos métodos de garantías y clasificaciones de riesgo usan `exchange()` con `ParameterizedTypeReference<List<...>>` igual que suscriptores, agentes y líneas de negocio.
+- Los fallbacks se nombran `riskClassificationsFallback(Exception ex)` y `guaranteesFallback(Exception ex)` — misma firma y comportamiento que `subscribersFallback` existente.
+- Las notas de URL externa: el mock expone `/v1/catalogs/risk-classification` (singular) para clasificaciones y `/v1/catalogs/guarantees` (plural) para garantías.
+- El filtro de `RiskClassificationDto` descarta si `id` o `nombre` son null/blank (consistente con `SubscriberDto`). El filtro de `GuaranteeDto` descarta si `id` o `nombre` son null/blank.
+- `application.yaml` no requiere cambios.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable para todos los agentes. Marcar cada ítem (`[x]`) al completarlo.
+> El Orchestrator monitorea este checklist para determinar el progreso.
+
+### Backend
+
+#### Implementación
+
+- [ ] Crear `model/dto/RiskClassificationDto.java` — campos `id`, `nombre`, `descripcion` (Lombok `@Data`)
+- [ ] Crear `model/dto/GuaranteeDto.java` — campos `id`, `nombre`, `claveIncendio`, `tarifable` (Lombok `@Data`)
+- [ ] Actualizar `client/CatalogsClient.java` — agregar `getRiskClassifications()` y `getGuarantees()`
+- [ ] Actualizar `client/CatalogsClientImpl.java` — implementar llamadas a `/v1/catalogs/risk-classification` y `/v1/catalogs/guarantees` con `ParameterizedTypeReference`
+- [ ] Actualizar `service/CatalogsService.java` — agregar `getRiskClassifications()` y `getGuarantees()`
+- [ ] Actualizar `service/CatalogsServiceImpl.java` — implementar con `@Retry(name="plataforma-core-ohs", fallbackMethod=...)`, filtros de registros inválidos, y fallbacks `riskClassificationsFallback` y `guaranteesFallback`
+- [ ] Actualizar `controller/CatalogsController.java` — agregar `GET /risk-classifications` y `GET /guarantees`
+- [ ] Verificar que `application.yaml` ya tiene la instancia retry `plataforma-core-ohs` configurada (no requiere cambios)
+
+#### Tests Backend
+
+- [ ] `getRiskClassifications_validList_returns200WithList` — happy path, lista con datos
+- [ ] `getRiskClassifications_emptyList_returnsEmptyList` — lista vacía retornada correctamente
+- [ ] `riskClassificationsFallback_whenCalled_throwsCatalogServiceUnavailableException` — fallback directo
+- [ ] `getRiskClassifications_recordMissingId_isDropped` — registro sin id descartado + log.warn
+- [ ] `getRiskClassifications_mapsAllFields` — id, nombre, descripcion preservados
+- [ ] `getGuarantees_validList_returns200WithList` — happy path, lista con datos
+- [ ] `getGuarantees_emptyList_returnsEmptyList` — lista vacía retornada correctamente
+- [ ] `guaranteesFallback_whenCalled_throwsCatalogServiceUnavailableException` — fallback directo
+- [ ] `getGuarantees_recordMissingNombre_isDropped` — registro con nombre vacío descartado + log.warn
+- [ ] `getGuarantees_mapsAllFields` — id, nombre, claveIncendio, tarifable preservados
+- [ ] `getCatalogsController_getRiskClassifications_returns200WithList` — controller delega al service, retorna 200
+- [ ] `getCatalogsController_getGuarantees_returns200WithList` — controller delega al service, retorna 200
+- [ ] `getCatalogsController_getRiskClassifications_serviceUnavailable_propagatesException` — excepción propagada
+- [ ] `getCatalogsController_getGuarantees_serviceUnavailable_propagatesException` — excepción propagada
+
+### Frontend
+
+No aplica a esta spec.
+
+### QA
+
+- [ ] Ejecutar skill `/gherkin-case-generator` → criterios CRITERIO-1.1 al 3.4
+- [ ] Ejecutar skill `/risk-identifier` → clasificar riesgo de dependencia (catálogos críticos para cobertura)
+- [ ] Verificar cobertura de tests ≥ 80% en `service/`, `client/`, `controller/`
+- [ ] Prueba de integración manual: levantar `plataforma-core-ohs` y hacer `GET /api/v1/catalogs/risk-classifications` → lista no vacía
+- [ ] Prueba de integración manual: `GET /api/v1/catalogs/guarantees` → lista no vacía con campos claveIncendio y tarifable
+- [ ] Prueba de resiliencia manual: apagar mock → 503 + log CRITICAL en ambos endpoints
+- [ ] Actualizar estado spec: `status: IMPLEMENTED`

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClient.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClient.java
@@ -2,6 +2,8 @@ package com.plataformas_danos_back.client;
 
 import com.plataformas_danos_back.model.dto.AgentDto;
 import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.GuaranteeDto;
+import com.plataformas_danos_back.model.dto.RiskClassificationDto;
 import com.plataformas_danos_back.model.dto.SubscriberDto;
 
 import java.util.List;
@@ -10,4 +12,6 @@ public interface CatalogsClient {
     List<SubscriberDto> getSubscribers();
     List<AgentDto> getAgents();
     List<BusinessLineDto> getBusinessLines();
+    List<RiskClassificationDto> getRiskClassifications();
+    List<GuaranteeDto> getGuarantees();
 }

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClientImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/client/CatalogsClientImpl.java
@@ -2,6 +2,8 @@ package com.plataformas_danos_back.client;
 
 import com.plataformas_danos_back.model.dto.AgentDto;
 import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.GuaranteeDto;
+import com.plataformas_danos_back.model.dto.RiskClassificationDto;
 import com.plataformas_danos_back.model.dto.SubscriberDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -54,6 +56,28 @@ public class CatalogsClientImpl implements CatalogsClient {
         String url = baseUrl + "/v1/business-lines";
         log.debug("Calling external service: GET {}", url);
         ResponseEntity<List<BusinessLineDto>> response = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<>() {}
+        );
+        return response.getBody();
+    }
+
+    @Override
+    public List<RiskClassificationDto> getRiskClassifications() {
+        String url = baseUrl + "/v1/catalogs/risk-classification";
+        log.debug("Calling external service: GET {}", url);
+        ResponseEntity<List<RiskClassificationDto>> response = restTemplate.exchange(
+                url, HttpMethod.GET, null,
+                new ParameterizedTypeReference<>() {}
+        );
+        return response.getBody();
+    }
+
+    @Override
+    public List<GuaranteeDto> getGuarantees() {
+        String url = baseUrl + "/v1/catalogs/guarantees";
+        log.debug("Calling external service: GET {}", url);
+        ResponseEntity<List<GuaranteeDto>> response = restTemplate.exchange(
                 url, HttpMethod.GET, null,
                 new ParameterizedTypeReference<>() {}
         );

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/controller/CatalogsController.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/controller/CatalogsController.java
@@ -2,6 +2,8 @@ package com.plataformas_danos_back.controller;
 
 import com.plataformas_danos_back.model.dto.AgentDto;
 import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.GuaranteeDto;
+import com.plataformas_danos_back.model.dto.RiskClassificationDto;
 import com.plataformas_danos_back.model.dto.SubscriberDto;
 import com.plataformas_danos_back.service.CatalogsService;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +34,15 @@ public class CatalogsController {
     @GetMapping("/business-lines")
     public ResponseEntity<List<BusinessLineDto>> getBusinessLines() {
         return ResponseEntity.ok(catalogsService.getBusinessLines());
+    }
+
+    @GetMapping("/risk-classifications")
+    public ResponseEntity<List<RiskClassificationDto>> getRiskClassifications() {
+        return ResponseEntity.ok(catalogsService.getRiskClassifications());
+    }
+
+    @GetMapping("/guarantees")
+    public ResponseEntity<List<GuaranteeDto>> getGuarantees() {
+        return ResponseEntity.ok(catalogsService.getGuarantees());
     }
 }

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/GuaranteeDto.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/GuaranteeDto.java
@@ -1,0 +1,15 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuaranteeDto {
+    private String id;
+    private String nombre;
+    private String claveIncendio;
+    private Boolean tarifable;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/RiskClassificationDto.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/RiskClassificationDto.java
@@ -1,0 +1,14 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RiskClassificationDto {
+    private String id;
+    private String nombre;
+    private String descripcion;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsService.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsService.java
@@ -2,6 +2,8 @@ package com.plataformas_danos_back.service;
 
 import com.plataformas_danos_back.model.dto.AgentDto;
 import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.GuaranteeDto;
+import com.plataformas_danos_back.model.dto.RiskClassificationDto;
 import com.plataformas_danos_back.model.dto.SubscriberDto;
 
 import java.util.List;
@@ -10,4 +12,6 @@ public interface CatalogsService {
     List<SubscriberDto> getSubscribers();
     List<AgentDto> getAgents();
     List<BusinessLineDto> getBusinessLines();
+    List<RiskClassificationDto> getRiskClassifications();
+    List<GuaranteeDto> getGuarantees();
 }

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsServiceImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/CatalogsServiceImpl.java
@@ -4,6 +4,8 @@ import com.plataformas_danos_back.client.CatalogsClient;
 import com.plataformas_danos_back.exception.CatalogServiceUnavailableException;
 import com.plataformas_danos_back.model.dto.AgentDto;
 import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.GuaranteeDto;
+import com.plataformas_danos_back.model.dto.RiskClassificationDto;
 import com.plataformas_danos_back.model.dto.SubscriberDto;
 import io.github.resilience4j.retry.annotation.Retry;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +54,28 @@ public class CatalogsServiceImpl implements CatalogsService {
         throw new CatalogServiceUnavailableException("Servicio de catálogos no disponible", ex);
     }
 
+    @Override
+    @Retry(name = "plataforma-core-ohs", fallbackMethod = "riskClassificationsFallback")
+    public List<RiskClassificationDto> getRiskClassifications() {
+        return filterValidRiskClassifications(catalogsClient.getRiskClassifications());
+    }
+
+    @Override
+    @Retry(name = "plataforma-core-ohs", fallbackMethod = "guaranteesFallback")
+    public List<GuaranteeDto> getGuarantees() {
+        return filterValidGuarantees(catalogsClient.getGuarantees());
+    }
+
+    public List<RiskClassificationDto> riskClassificationsFallback(Exception ex) {
+        log.error("CRITICAL: Catalog service unavailable after retries — risk-classifications. Error: {}", ex.getMessage());
+        throw new CatalogServiceUnavailableException("Servicio de catálogos no disponible", ex);
+    }
+
+    public List<GuaranteeDto> guaranteesFallback(Exception ex) {
+        log.error("CRITICAL: Catalog service unavailable after retries — guarantees. Error: {}", ex.getMessage());
+        throw new CatalogServiceUnavailableException("Servicio de catálogos no disponible", ex);
+    }
+
     private List<SubscriberDto> filterValidSubscribers(List<SubscriberDto> list) {
         if (list == null) return List.of();
         return list.stream()
@@ -96,6 +120,40 @@ public class CatalogsServiceImpl implements CatalogsService {
                     }
                     if (b.getDescripcion() == null || b.getDescripcion().isBlank()) {
                         log.warn("BusinessLine record dropped: missing required field 'descripcion', id={}", b.getId());
+                        return false;
+                    }
+                    return true;
+                })
+                .toList();
+    }
+
+    private List<RiskClassificationDto> filterValidRiskClassifications(List<RiskClassificationDto> list) {
+        if (list == null) return List.of();
+        return list.stream()
+                .filter(r -> {
+                    if (r.getId() == null || r.getId().isBlank()) {
+                        log.warn("RiskClassification record dropped: missing required field 'id'");
+                        return false;
+                    }
+                    if (r.getNombre() == null || r.getNombre().isBlank()) {
+                        log.warn("RiskClassification record dropped: missing required field 'nombre', id={}", r.getId());
+                        return false;
+                    }
+                    return true;
+                })
+                .toList();
+    }
+
+    private List<GuaranteeDto> filterValidGuarantees(List<GuaranteeDto> list) {
+        if (list == null) return List.of();
+        return list.stream()
+                .filter(g -> {
+                    if (g.getId() == null || g.getId().isBlank()) {
+                        log.warn("Guarantee record dropped: missing required field 'id'");
+                        return false;
+                    }
+                    if (g.getNombre() == null || g.getNombre().isBlank()) {
+                        log.warn("Guarantee record dropped: missing required field 'nombre', id={}", g.getId());
                         return false;
                     }
                     return true;

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/controller/CatalogsControllerTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/controller/CatalogsControllerTest.java
@@ -3,6 +3,8 @@ package com.plataformas_danos_back.controller;
 import com.plataformas_danos_back.exception.CatalogServiceUnavailableException;
 import com.plataformas_danos_back.model.dto.AgentDto;
 import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.GuaranteeDto;
+import com.plataformas_danos_back.model.dto.RiskClassificationDto;
 import com.plataformas_danos_back.model.dto.SubscriberDto;
 import com.plataformas_danos_back.service.CatalogsService;
 import org.junit.jupiter.api.Test;
@@ -129,5 +131,74 @@ class CatalogsControllerTest {
         // WHEN / THEN
         assertThatThrownBy(() -> controller.getBusinessLines())
                 .isInstanceOf(CatalogServiceUnavailableException.class);
+    }
+
+    // ── Risk Classifications ─────────────────────────────────────────────────
+
+    @Test
+    void getCatalogsController_getRiskClassifications_returns200WithList() {
+        // GIVEN
+        var classifications = List.of(
+                new RiskClassificationDto("RC-001", "Riesgo Bajo", "Clasificación para riesgos con baja probabilidad."),
+                new RiskClassificationDto("RC-002", "Riesgo Medio", "Clasificación para riesgos con probabilidad media.")
+        );
+        when(catalogsService.getRiskClassifications()).thenReturn(classifications);
+
+        // WHEN
+        var response = controller.getRiskClassifications();
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody().get(0).getId()).isEqualTo("RC-001");
+        assertThat(response.getBody().get(0).getNombre()).isEqualTo("Riesgo Bajo");
+    }
+
+    @Test
+    void getCatalogsController_getRiskClassifications_serviceUnavailable_propagatesException() {
+        // GIVEN — GlobalExceptionHandler transforma la excepción en 503 en el contexto HTTP;
+        // aquí verificamos que el controlador no la suprime
+        when(catalogsService.getRiskClassifications())
+                .thenThrow(new CatalogServiceUnavailableException("Servicio de catálogos no disponible"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> controller.getRiskClassifications())
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
+    }
+
+    // ── Guarantees ──────────────────────────────────────────────────────────
+
+    @Test
+    void getCatalogsController_getGuarantees_returns200WithList() {
+        // GIVEN
+        var guarantees = List.of(
+                new GuaranteeDto("GUA-001", "Robo con Violencia", "RV", true),
+                new GuaranteeDto("GUA-002", "Daños por Agua", "DA", false)
+        );
+        when(catalogsService.getGuarantees()).thenReturn(guarantees);
+
+        // WHEN
+        var response = controller.getGuarantees();
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+        assertThat(response.getBody().get(0).getId()).isEqualTo("GUA-001");
+        assertThat(response.getBody().get(0).getClaveIncendio()).isEqualTo("RV");
+        assertThat(response.getBody().get(0).getTarifable()).isTrue();
+    }
+
+    @Test
+    void getCatalogsController_getGuarantees_serviceUnavailable_propagatesException() {
+        // GIVEN — GlobalExceptionHandler transforma la excepción en 503 en el contexto HTTP;
+        // aquí verificamos que el controlador no la suprime
+        when(catalogsService.getGuarantees())
+                .thenThrow(new CatalogServiceUnavailableException("Servicio de catálogos no disponible"));
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> controller.getGuarantees())
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
     }
 }

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/CatalogsServiceImplTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/CatalogsServiceImplTest.java
@@ -4,6 +4,8 @@ import com.plataformas_danos_back.client.CatalogsClient;
 import com.plataformas_danos_back.exception.CatalogServiceUnavailableException;
 import com.plataformas_danos_back.model.dto.AgentDto;
 import com.plataformas_danos_back.model.dto.BusinessLineDto;
+import com.plataformas_danos_back.model.dto.GuaranteeDto;
+import com.plataformas_danos_back.model.dto.RiskClassificationDto;
 import com.plataformas_danos_back.model.dto.SubscriberDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -194,5 +196,146 @@ class CatalogsServiceImplTest {
         // THEN
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo("BL-001");
+    }
+
+    // ── Risk Classifications ─────────────────────────────────────────────────
+
+    @Test
+    void getRiskClassifications_validList_returns200WithList() {
+        // GIVEN
+        var rc = new RiskClassificationDto("RC-001", "Riesgo Bajo", "Clasificación para riesgos con baja probabilidad.");
+        when(catalogsClient.getRiskClassifications()).thenReturn(List.of(rc));
+
+        // WHEN
+        var result = service.getRiskClassifications();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("RC-001");
+    }
+
+    @Test
+    void getRiskClassifications_emptyList_returnsEmptyList() {
+        // GIVEN
+        when(catalogsClient.getRiskClassifications()).thenReturn(List.of());
+
+        // WHEN
+        var result = service.getRiskClassifications();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void riskClassificationsFallback_whenCalled_throwsCatalogServiceUnavailableException() {
+        // GIVEN
+        var cause = new RuntimeException("Connection refused");
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> service.riskClassificationsFallback(cause))
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
+    }
+
+    @Test
+    void getRiskClassifications_recordMissingId_isDropped() {
+        // GIVEN
+        var valid = new RiskClassificationDto("RC-001", "Riesgo Bajo", "Descripción");
+        var missingId = new RiskClassificationDto(null, "Sin ID", "Descripción");
+        when(catalogsClient.getRiskClassifications()).thenReturn(List.of(valid, missingId));
+
+        // WHEN
+        var result = service.getRiskClassifications();
+
+        // THEN — solo el registro válido se retorna
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("RC-001");
+    }
+
+    @Test
+    void getRiskClassifications_mapsAllFields() {
+        // GIVEN
+        var rc = new RiskClassificationDto("RC-001", "Riesgo Bajo", "Clasificación para riesgos con baja probabilidad.");
+        when(catalogsClient.getRiskClassifications()).thenReturn(List.of(rc));
+
+        // WHEN
+        var result = service.getRiskClassifications();
+
+        // THEN
+        var dto = result.get(0);
+        assertThat(dto.getId()).isEqualTo("RC-001");
+        assertThat(dto.getNombre()).isEqualTo("Riesgo Bajo");
+        assertThat(dto.getDescripcion()).isEqualTo("Clasificación para riesgos con baja probabilidad.");
+    }
+
+    // ── Guarantees ──────────────────────────────────────────────────────────
+
+    @Test
+    void getGuarantees_validList_returns200WithList() {
+        // GIVEN
+        var guarantee = new GuaranteeDto("GUA-001", "Robo con Violencia", "RV", true);
+        when(catalogsClient.getGuarantees()).thenReturn(List.of(guarantee));
+
+        // WHEN
+        var result = service.getGuarantees();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("GUA-001");
+    }
+
+    @Test
+    void getGuarantees_emptyList_returnsEmptyList() {
+        // GIVEN
+        when(catalogsClient.getGuarantees()).thenReturn(List.of());
+
+        // WHEN
+        var result = service.getGuarantees();
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void guaranteesFallback_whenCalled_throwsCatalogServiceUnavailableException() {
+        // GIVEN
+        var cause = new RuntimeException("Timeout");
+
+        // WHEN / THEN
+        assertThatThrownBy(() -> service.guaranteesFallback(cause))
+                .isInstanceOf(CatalogServiceUnavailableException.class)
+                .hasMessage("Servicio de catálogos no disponible");
+    }
+
+    @Test
+    void getGuarantees_recordMissingNombre_isDropped() {
+        // GIVEN
+        var valid = new GuaranteeDto("GUA-001", "Robo con Violencia", "RV", true);
+        var missingNombre = new GuaranteeDto("GUA-002", "", "DA", false);
+        when(catalogsClient.getGuarantees()).thenReturn(List.of(valid, missingNombre));
+
+        // WHEN
+        var result = service.getGuarantees();
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo("GUA-001");
+    }
+
+    @Test
+    void getGuarantees_mapsAllFields() {
+        // GIVEN
+        var guarantee = new GuaranteeDto("GUA-001", "Robo con Violencia", "RV", true);
+        when(catalogsClient.getGuarantees()).thenReturn(List.of(guarantee));
+
+        // WHEN
+        var result = service.getGuarantees();
+
+        // THEN
+        var dto = result.get(0);
+        assertThat(dto.getId()).isEqualTo("GUA-001");
+        assertThat(dto.getNombre()).isEqualTo("Robo con Violencia");
+        assertThat(dto.getClaveIncendio()).isEqualTo("RV");
+        assertThat(dto.getTarifable()).isTrue();
     }
 }


### PR DESCRIPTION
## Extensión de catálogos para clasificación de riesgo y garantías

* Se agregan endpoints `GET /api/v1/catalogs/risk-classifications` y `GET /api/v1/catalogs/guarantees`
* Se extiende `CatalogsClient` y `CatalogsService` reutilizando el patrón existente de integración con `plataforma-core-ohs`
* Se implementan llamadas HTTP con `RestTemplate` y resiliencia (Resilience4j) ante errores `5xx` y de red
* Se incorporan DTOs `RiskClassificationDto` y `GuaranteeDto` con mapeo completo de campos
* Se aplica filtrado de registros inválidos (id/nombre null o blank) con logging `WARNING`
* Manejo de errores consistente mediante fallback a `503 CATALOG_SERVICE_UNAVAILABLE`
* Se agregan tests para flujos exitosos, listas vacías, filtrado de datos inválidos, mapeo y propagación de errores
