### PR TITLE
EP-003 FT-021 Core | Validacion datos

### DIFF
--- a/.claude/agent-memory/backend-developer/MEMORY.md
+++ b/.claude/agent-memory/backend-developer/MEMORY.md
@@ -1,3 +1,4 @@
 # Memory Index
 
 - [plataforma-core-ohs mock server implementado](project_plataforma_core_ohs.md) — Mock Node.js/Express para EP-003 FT-020, estructura src/ completa con 10 modelos, 9 migraciones y 14 endpoints
+- [FT-021 — Validación de Datos Maestros implementada](project_ft021_validation.md) — Capa de validación en plataformas-danos-back: 24 artefactos nuevos, 3 paquetes nuevos, spec IN_PROGRESS

--- a/.claude/agent-memory/backend-developer/project_ft021_validation.md
+++ b/.claude/agent-memory/backend-developer/project_ft021_validation.md
@@ -1,0 +1,32 @@
+---
+name: FT-021 — Validación y Gestión de Inconsistencias implementada
+description: Capa de validación de datos maestros en plataformas-danos-back, paquetes nuevos creados y artefactos añadidos a paquetes existentes
+type: project
+---
+
+FT-021 implementado en `plataformas-danos-back`. Status spec: IN_PROGRESS.
+
+**Nuevos paquetes creados:**
+- `model/entity/` — DataInconsistency, ValidationRule, CorrectionRule
+- `repository/` — DataInconsistencyRepository, ValidationRuleRepository, CorrectionRuleRepository
+
+**Archivos añadidos a paquetes existentes:**
+- `model/dto/` — ValidationRequest, ValidationResult, ValidationErrorDetail, CorrectionResult, DataInconsistencyResponse
+- `service/` — DataValidationEngine/Impl, DataCorrectionService/Impl, InconsistencyNotificationService/Impl, DataValidationService/Impl
+- `config/` — ValidationProperties, ValidationRulesConfig (CommandLineRunner seed)
+- `controller/` — DataValidationController (`/api/v1/data-validation`)
+- `exception/` — ValidationException, InvalidRuleException, InconsistencyRecordException
+
+**Reglas de negocio implementadas:** NOT_NULL, NOT_EMPTY, POSITIVE_NUMBER, FORMAT_REGEX para SUBSCRIBER, AGENT, BUSINESS_LINE, ZIP_CODE, TARIFF_CAT, TARIFF_FIRE, TARIFF_ELECTRONIC.
+
+**Corrección automática:** TRIM en campos descriptivos de nombre/ciudad/estado, DEFAULT_VALUE y NORMALIZE_CASE disponibles.
+
+**application.yaml:** propiedad `validation.inconsistency-threshold-percent` añadida (default 10).
+
+**Pendiente (fuera de scope de esta tarea):**
+- Integración en CatalogsServiceImpl, TariffsServiceImpl, ZipCodeServiceImpl
+- Extensión de DTOs existentes con campo dataStatus
+- Caché Caffeine explícita para ValidationRule
+
+**Why:** Spec SPEC-007 aprobada, implementación síncrona por decisión de diseño.
+**How to apply:** Al tocar validaciones o agregar nuevos tipos de datos maestros, agregar reglas en ValidationRulesConfig y seguir el mismo patrón de servicio.

--- a/.claude/agent-memory/spec-generator/MEMORY.md
+++ b/.claude/agent-memory/spec-generator/MEMORY.md
@@ -1,0 +1,3 @@
+# Spec Generator Memory Index
+
+- [SPEC-007 — FT-021 Data Validation Layer](spec-007-validacion-datos.md) — Transversal validation framework for master data consistency, 3 HUs, synchronous integration

--- a/.claude/agent-memory/spec-generator/spec-007-validacion-datos.md
+++ b/.claude/agent-memory/spec-generator/spec-007-validacion-datos.md
@@ -1,0 +1,46 @@
+---
+name: SPEC-007 FT-021 — Data Validation Layer
+description: Generated 2026-04-27 — comprehensive validation framework for master data consistency
+type: project
+---
+
+## Summary
+
+Generated SPEC-007 for feature `ep-003-ft-021-core-validacion-datos` (FT-021 — Data Validation and Inconsistency Management). This spec covers a transversal validation layer for master data (catalogs, tarifas, zip codes) with:
+
+- **Three HUs**: HU-100 (validation), HU-101 (inconsistency recording), HU-102 (critical alerts)
+- **Six business rules**: BR-001 (NOT_NULL), BR-002 (positivity), BR-003 (postal format), BR-004 (states), BR-005 (severity levels), BR-006 (audit logging)
+- **Two MongoDB collections**: `data-inconsistencies` (with 90-day TTL) and `validation-rules`
+- **Four API endpoints**: POST /validate, GET /inconsistencies, GET /rules, POST/PUT /rules (admin)
+- **Transversal architecture**: Integration points in CatalogsServiceImpl, TariffsServiceImpl, ZipCodeServiceImpl
+
+**SPEC ID assigned**: SPEC-007 (following SPEC-001 through SPEC-006)
+
+## Key Design Decisions
+
+1. **Synchronous validation**: Validates immediately after receiving external data (not async) to ensure cache consistency
+2. **Severity-based handling**: CRITICAL/ERROR blocks; WARNING logs but allows processing
+3. **Cacheable rules**: ValidationRule cached in memory (Caffeine, 1h TTL) — changes require restart or manual invalidation
+4. **Filtering at source**: Backend filters INCONSISTENT records before exposing to frontend (transparent to UI)
+5. **Strategy pattern extensibility**: New validation types addable via new ValidationRule implementations
+
+## Related Specs
+
+- SPEC-001: Mock server base
+- SPEC-003: Catalogs (subscribers, agents, lines)
+- SPEC-004: Zip codes
+- SPEC-005: Risk classification
+- SPEC-006: Tariffs (CAT, Fire, Electronic Equipment)
+
+FT-021 adds the validation/quality layer after all upstream data integrations.
+
+## Implementation Scope
+
+**Backend only** (for SPEC-007):
+- DataValidationService + Engine
+- DataInconsistency + ValidationRule repositories
+- DataValidationController + DTOs
+- Integration in existing catalog/tariff/zipcode services
+- 25+ test cases targeting ≥90% coverage
+
+**Frontend**: None (validations are transparent, backend filters results)

--- a/.github/specs/ep-003-ft-021-core-validacion-datos.spec.md
+++ b/.github/specs/ep-003-ft-021-core-validacion-datos.spec.md
@@ -1,0 +1,934 @@
+---
+id: SPEC-007
+status: IN_PROGRESS
+feature: ep-003-ft-021-core-validacion-datos
+created: 2026-04-27
+updated: 2026-04-27
+author: spec-generator
+version: "1.0"
+related-specs:
+  - SPEC-001
+  - SPEC-003
+  - SPEC-004
+  - SPEC-005
+  - SPEC-006
+---
+
+# Spec: FT-021 — Validación y Gestión de Inconsistencias en Datos Maestros
+
+> **Estado:** `DRAFT` → aprobar con `status: APPROVED` antes de iniciar implementación.
+> **Ciclo de vida:** DRAFT → APPROVED → IN_PROGRESS → IMPLEMENTED → DEPRECATED
+
+---
+
+## 1. REQUERIMIENTOS
+
+### Descripción
+
+Esta feature implementa una capa transversal de validación en `plataformas-danos-back` encargada de validar, detectar, registrar y gestionar inconsistencias en los datos maestros provenientes de servicios externos (`Plataforma-core-ohs` o su mock), asegurando su calidad e integridad antes de ser utilizados por el sistema para cálculos de primas y operaciones de cotización.
+
+### Requerimiento de Negocio
+
+Garantizar la integridad, consistencia y confiabilidad de los datos maestros (catálogos de suscriptores, agentes, giros, códigos postales, tarifas, clasificaciones de riesgo) mediante validaciones automáticas de campos obligatorios, formato y valor, detectando inconsistencias y permitiendo su gestión (rechazo, notificación o corrección), minimizando el riesgo de errores en el cálculo de primas y operaciones del cotizador.
+
+### Historias de Usuario
+
+#### HU-100: Validar campos obligatorios y formato en datos maestros (HU-100)
+
+```
+Como:        Sistema (plataformas-danos-back)
+Quiero:      Validar que los datos maestros cumplan con reglas de negocio (nulos, formato, valor)
+Para:        Asegurar que los datos recibidos de plataforma-core-ohs son consistentes y válidos
+
+Prioridad:   Alta
+Estimación:  M (5 story points)
+Dependencias: SPEC-001, SPEC-003, SPEC-004, SPEC-005, SPEC-006 (datos maestros disponibles)
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-100
+
+**Happy Path**
+
+```gherkin
+CRITERIO-100.1: Validación exitosa de catálogo de suscriptores válido
+  Dado que:  se recibe un catálogo de suscriptores con id y nombre válidos (no nulos, no vacíos)
+  Cuando:    el módulo de validación procesa el registro
+  Entonces:  el estado del registro cambia a VALIDATED
+             y no se generan errores de validación
+
+CRITERIO-100.2: Validación exitosa de tarifa CAT con factor positivo
+  Dado que:  se recibe una tarifa CAT con factores numéricos positivos (>0)
+  Cuando:    el módulo de validación procesa el registro
+  Entonces:  el estado del registro cambia a VALIDATED
+             y se permite su uso en cálculos de primas
+
+CRITERIO-100.3: Validación exitosa de código postal con formato correcto
+  Dado que:  se recibe un código postal con 5 dígitos numéricos (patrón /^[0-9]{5}$/)
+  Cuando:    el módulo de validación procesa el registro
+  Entonces:  el estado del registro cambia a VALIDATED
+             y el código postal es aceptado
+```
+
+**Error Path**
+
+```gherkin
+CRITERIO-100.4: Detección de campo obligatorio nulo en suscriptor
+  Dado que:  se recibe un catálogo de suscriptores con el campo 'id' o 'nombre' nulo
+  Cuando:    el módulo de validación procesa el registro
+  Entonces:  el estado cambia a INCONSISTENT
+             y se registra mensaje de error: "Campo 'id' es obligatorio y no puede ser nulo"
+             y se genera un log de validación con tipo de error y campo afectado
+
+CRITERIO-100.5: Detección de factor de tarifa negativo o cero
+  Dado que:  se recibe una tarifa CAT con factor <= 0
+  Cuando:    el módulo de validación procesa el registro
+  Entonces:  el estado cambia a INCONSISTENT
+             y se registra mensaje: "Campo 'factor' debe ser un número positivo (>0)"
+             y el registro es rechazado para su uso
+
+CRITERIO-100.6: Detección de código postal con formato incorrecto
+  Dado que:  se recibe un código postal que no cumple el patrón /^[0-9]{5}$/
+  Cuando:    el módulo de validación procesa el registro
+  Entonces:  el estado cambia a INCONSISTENT
+             y se registra mensaje: "Código postal debe contener exactamente 5 dígitos numéricos"
+             y el registro es marcado como inválido
+```
+
+**Edge Case**
+
+```gherkin
+CRITERIO-100.7: Validación de campo con valor vacío (cadena vacía)
+  Dado que:  se recibe un registro con un campo obligatorio como cadena vacía ""
+  Cuando:    el módulo de validación procesa el registro
+  Entonces:  es tratado igual que un nulo
+             y el estado cambia a INCONSISTENT
+
+CRITERIO-100.8: Manejo de esquema inesperado
+  Dado que:  se recibe un dato maestro con un tipo de dato inesperado (ej. string en lugar de número)
+  Cuando:    el módulo de validación intenta aplicar las reglas
+  Entonces:  el estado cambia a INCONSISTENT
+             y se registra: "Error de esquema: Campo 'factor' debe ser numérico"
+             y se genera un log de error con el tipo de dato recibido
+```
+
+---
+
+#### HU-101: Registrar inconsistencias detectadas (HU-101)
+
+```
+Como:        Administrador / Sistema (auditor)
+Quiero:      Que todas las inconsistencias se registren persistentemente para auditoría y análisis
+Para:        Tener trazabilidad de qué datos fueron rechazados, cuándo y por qué
+
+Prioridad:   Alta
+Estimación:  S (3 story points)
+Dependencias: HU-100 (validación ejecutada)
+Capa:        Backend (Java/Spring Boot + MongoDB)
+```
+
+#### Criterios de Aceptación — HU-101
+
+**Happy Path**
+
+```gherkin
+CRITERIO-101.1: Registro de inconsistencia en MongoDB
+  Dado que:  se detecta una inconsistencia en un dato maestro
+  Cuando:    se intenta registrar en la colección "data-inconsistencies"
+  Entonces:  se crea un documento con campos: id, dataType, value, validationError, status, timestamp
+             y el registro se persiste en MongoDB
+             y se retorna un ID único del registro de inconsistencia
+
+CRITERIO-101.2: Estructura JSON de log estructurado
+  Dado que:  se registra una inconsistencia
+  Cuando:    se genera el log estructurado
+  Entonces:  el formato es JSON con campos: correlationId, timestamp, dataType, error, severity
+             y es compatible con herramientas de análisis de logs
+```
+
+**Error Path**
+
+```gherkin
+CRITERIO-101.3: Fallo en persistencia de inconsistencia
+  Dado que:  MongoDB no está disponible
+  Cuando:    se intenta registrar una inconsistencia
+  Entonces:  se registra un log de error con código "PERSISTENCE_ERROR"
+             y se notifica al sistema de la falla
+             y no falla el procesamiento general (no bloquea validación)
+```
+
+---
+
+#### HU-102: Aplicar Corrección Automática de Inconsistencias (HU-102)
+
+```
+Como:        Sistema (plataformas-danos-back)
+Quiero:      Aplicar reglas de corrección automática para tipos de inconsistencias predefinidos
+Para:        Mantener la calidad del dato sin intervención manual en casos simples
+
+Prioridad:   Media
+Estimación:  M (4 story points)
+Dependencias: HU-100, HU-101
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-102
+
+**Happy Path**
+
+```gherkin
+CRITERIO-102.1: Corrección automática de inconsistencia de formato menor
+  Dado que:  se detecta una inconsistencia de formato menor (ej. espacios extra en un campo de texto)
+  Cuando:    el módulo de corrección automática la procesa
+  Entonces:  aplica la regla de limpieza (trim) y corrige el dato automáticamente
+             y el dato queda en estado VALIDATED con corrección aplicada
+
+CRITERIO-102.2: Asignación de valor por defecto en campo opcional nulo
+  Dado que:  se detecta un dato nulo en un campo opcional con valor por defecto definido
+  Cuando:    el módulo de corrección lo procesa
+  Entonces:  le asigna el valor por defecto predefinido para ese campo
+             y registra que se aplicó corrección automática
+```
+
+**Edge Case**
+
+```gherkin
+CRITERIO-102.3: Registro del valor original al aplicar corrección
+  Dado que:  se aplica una corrección automática sobre un dato
+  Cuando:    el sistema registra la corrección
+  Entonces:  persiste el valor original del dato antes de la corrección
+             y el log de inconsistencia incluye: valorOriginal, valorCorregido, reglaAplicada
+
+CRITERIO-102.4: Inconsistencia no corregible automáticamente
+  Dado que:  se detecta una inconsistencia que no tiene regla de corrección automática definida
+  Cuando:    el módulo de corrección la evalúa
+  Entonces:  el dato permanece en estado INCONSISTENT
+             y se delega a HU-103 para notificación
+```
+
+---
+
+#### HU-103: Notificar Inconsistencias que Requieren Intervención (HU-103)
+
+```
+Como:        Sistema (plataformas-danos-back)
+Quiero:      Activar una notificación (log de nivel ERROR, alerta) cuando se detectan inconsistencias
+             que requieren intervención manual
+Para:        Asegurar su resolución oportuna y evitar que afecten el negocio
+
+Prioridad:   Alta
+Estimación:  S (3 story points)
+Dependencias: HU-100, HU-101, HU-102
+Capa:        Backend (Java/Spring Boot)
+```
+
+#### Criterios de Aceptación — HU-103
+
+**Happy Path**
+
+```gherkin
+CRITERIO-103.1: Alerta por inconsistencia crítica no corregible automáticamente
+  Dado que:  se detecta una inconsistencia crítica que no puede corregirse automáticamente
+  Cuando:    el sistema finaliza el procesamiento del dato
+  Entonces:  envía una alerta (log ERROR estructurado) a los administradores
+             con detalles: tipo de dato, campo afectado, regla violada, ID del registro de inconsistencia
+
+CRITERIO-103.2: Notificación incluye enlace al registro de inconsistencia
+  Dado que:  se envía una notificación de inconsistencia crítica
+  Cuando:    el sistema la genera
+  Entonces:  incluye el ID del registro en la colección "data-inconsistencies"
+             para que el administrador pueda acceder al detalle
+```
+
+**Edge Case**
+
+```gherkin
+CRITERIO-103.3: Alerta de alto nivel al superar umbral de inconsistencias
+  Dado que:  se supera el umbral configurado de inconsistencias en un lote (ej. > 10% de registros)
+  Cuando:    el sistema completa la validación del lote
+  Entonces:  emite una alerta de alto nivel con el resumen: total, críticas, warnings
+             diferenciada de las alertas individuales por registro
+
+CRITERIO-103.4: No bloqueo del flujo por fallo en notificación
+  Dado que:  el mecanismo de notificación (ej. email, Slack) no está disponible
+  Cuando:    el sistema intenta enviar la alerta
+  Entonces:  registra el fallo de notificación en el log de aplicación
+             y continúa el procesamiento sin propagar la excepción
+```
+
+---
+
+#### HU-104: Definir Reglas de Validación con Analistas Funcionales (HU-104)
+
+```
+Como:        Analista funcional
+Quiero:      Definir las reglas de validación de datos maestros en conjunto con el equipo técnico
+Para:        Asegurar que cubren los casos de negocio y las expectativas de calidad del dato
+
+Prioridad:   Alta
+Estimación:  2 días (análisis y documentación)
+Dependencias: HU-100, HU-102
+Capa:        Documentación + Backend (reglas configurables)
+```
+
+#### Criterios de Aceptación — HU-104
+
+**Happy Path**
+
+```gherkin
+CRITERIO-104.1: Definición de reglas por campo en contratos de API
+  Dado que:  se definen los contratos de API de los datos maestros
+  Cuando:    los analistas funcionales revisan los campos
+  Entonces:  cada campo relevante tiene documentada su regla de validación:
+             tipo (NOT_NULL, POSITIVE_NUMBER, FORMAT_REGEX), severidad y mensaje de error
+
+CRITERIO-104.2: Clasificación de inconsistencias entre corrección automática y notificación
+  Dado que:  se identifican posibles inconsistencias en los datos maestros
+  Cuando:    los analistas funcionales las revisan
+  Entonces:  cada tipo de inconsistencia está clasificado como:
+             "corrección automática" (HU-102) o "requiere intervención" (HU-103)
+
+CRITERIO-104.3: Reglas implementadas cubren las definiciones documentadas
+  Dado que:  las reglas de validación están documentadas en la especificación
+  Cuando:    el equipo de desarrollo las implementa en ValidationRule
+  Entonces:  existe un test por cada regla documentada que verifica su correcta aplicación
+```
+
+---
+
+### Reglas de Negocio
+
+#### BR-001: Validación de campos obligatorios
+- **Descripción**: Todos los campos marcados como obligatorios en un tipo de dato maestro no pueden ser nulos o cadenas vacías.
+- **Trigger**: Al procesar cualquier dato maestro desde catálogos, tarifas, códigos postales, etc.
+- **Lógica**: `IF campo IS NULL OR campo == "" THEN estado = INCONSISTENT AND registrar error`
+- **Aplicable a**: 
+  - Suscriptores: `id`, `nombre`
+  - Agentes: `id`, `nombre`
+  - Giros: `id`, `nombre`
+  - Códigos postales: `codigo`, `ciudad`, `estado`
+
+#### BR-002: Validación de positividad en campos numéricos
+- **Descripción**: Campos numéricos específicos (factores de tarifa) deben ser valores mayores que cero.
+- **Trigger**: Al procesar datos maestros con factores (tarifas CAT, fire, electronic equipment).
+- **Lógica**: `IF factor <= 0 THEN estado = INCONSISTENT AND registrar error "valor debe ser >0"`
+- **Aplicable a**:
+  - TariffCat: `factorTEV`, `factorFHM` (ambos > 0)
+  - TariffFire: `factor` (> 0)
+  - TariffElectronicEquipment: `factor` (> 0)
+
+#### BR-003: Validación de formato de código postal
+- **Descripción**: El campo `codigo` de un código postal debe coincidir con el patrón de 5 dígitos numéricos.
+- **Trigger**: Al procesar datos maestros de códigos postales.
+- **Lógica**: `IF codigo NOT MATCH /^[0-9]{5}$/ THEN estado = INCONSISTENT AND registrar error`
+- **Validación adicional**: El código debe existir y estar activo en el catálogo de municipios/estados válidos (si aplica).
+
+#### BR-004: Estados de validación
+- **Valores permitidos**: `PENDING_VALIDATION` | `VALIDATED` | `INCONSISTENT`
+- **Transiciones**:
+  - Inicial: `PENDING_VALIDATION`
+  - Después de validación exitosa: `VALIDATED`
+  - Después de detectar inconsistencia: `INCONSISTENT` (irreversible)
+- **Restricción**: Un registro con estado `INCONSISTENT` nunca cambia a `VALIDATED`.
+
+#### BR-005: Niveles de severidad de inconsistencias
+- **ERROR / CRÍTICO**: Falta campo obligatorio, valor está completamente fuera de rango, tipo de dato incorrecto.
+- **WARNING**: Validación adicional fallida (ej. código postal válido pero no existe en catálogo de municipios).
+- **INFO**: Validación pasada pero con recomendación (ej. campo con largo máximo cercano al límite).
+
+#### BR-006: Registro de auditoría
+- **Obligatorio registrar**: Timestamp (UTC), tipo de dato, ID del registro, campo afectado, regla violada, severidad.
+- **Formato**: Logs JSON estructurados con `correlation-id` para trazabilidad de transacciones.
+- **Retención**: Mínimo 90 días en MongoDB; logs de aplicación archivados diariamente.
+
+#### BR-007: Reglas de corrección automática
+- Solo se aplican correcciones automáticas a inconsistencias explícitamente definidas (no se crean correcciones implícitas).
+- Correcciones permitidas: `TRIM` (espacios extra), `DEFAULT_VALUE` (null en campo opcional), `UPPERCASE/LOWERCASE` (normalización de casing).
+- Las correcciones no aplican sobre campos clave (ID, zona, código) — solo sobre campos descriptivos o auxiliares.
+- Toda corrección guarda el valor original antes de modificarlo (`valorOriginal`, `valorCorregido`, `reglaCorrección`).
+
+#### BR-008: Umbral de alertas de inconsistencias
+- Si más del 10% de los registros de un lote resultan INCONSISTENT, se emite una alerta de alto nivel (log ERROR).
+- Los umbrales son configurables vía `application.yml` (`validation.inconsistency-threshold-percent`, default: 10).
+- Inconsistencias de nivel CRITICAL activan notificación individual independientemente del umbral.
+
+#### BR-009: Definición colaborativa de reglas
+- Ninguna regla de validación se implementa sin la aprobación del analista funcional responsable.
+- El catálogo de reglas (`ValidationRule`) es la fuente de verdad; cualquier cambio requiere actualizar spec y tests.
+
+---
+
+## 2. DISEÑO
+
+### Modelos de Datos
+
+#### Entidades afectadas
+
+| Entidad | Almacén | Cambios | Descripción |
+|---------|---------|---------|-------------|
+| `DataInconsistency` | `data-inconsistencies` (MongoDB) | nueva | Registro de inconsistencias detectadas en datos maestros |
+| `ValidationRule` | `validation-rules` (MongoDB) | nueva | Definiciones configurables de reglas de validación |
+| `SubscriberDto` | memory/cache | extensión | Agregar campo `dataStatus` (PENDING_VALIDATION, VALIDATED, INCONSISTENT) |
+| `TariffCatDto` | memory/cache | extensión | Agregar campo `dataStatus` |
+| `ZipCodeDto` | memory/cache | extensión | Agregar campo `dataStatus` |
+
+#### Campos del modelo — DataInconsistency
+
+| Campo | Tipo | Obligatorio | Validación | Descripción |
+|-------|------|-------------|------------|-------------|
+| `id` | string | sí | auto-generado (UUID) | Identificador único del registro de inconsistencia |
+| `dataType` | enum | sí | SUBSCRIBER, AGENT, BUSINESS_LINE, ZIP_CODE, TARIFF_CAT, TARIFF_FIRE, TARIFF_ELECTRONIC | Tipo de dato maestro validado |
+| `dataId` | string | sí | referencia al id del dato original | ID del registro de datos maestros que falló validación |
+| `value` | object | sí | JSON del registro original | Copia completa del dato que fue rechazado |
+| `validationError` | object | sí | `{ field: string, rule: string, message: string, severity: string }` | Detalles del error de validación |
+| `status` | string | sí | CRITICAL, WARNING, INFO | Nivel de severidad de la inconsistencia |
+| `correlationId` | string | sí | heredado del contexto de request | ID de correlación para auditoría |
+| `createdAt` | datetime (UTC) | sí | auto-generado | Timestamp de detección de inconsistencia |
+| `resolvedAt` | datetime (UTC) | no | null hasta que se resuelva | Timestamp cuando se resuelve o archiva |
+| `resolution` | string | no | null | Nota de cómo se resolvió (manual/automática) |
+
+#### Campos del modelo — ValidationRule
+
+| Campo | Tipo | Obligatorio | Validación | Descripción |
+|-------|------|-------------|------------|-------------|
+| `id` | string | sí | auto-generado (UUID) | ID de la regla |
+| `dataType` | enum | sí | SUBSCRIBER, AGENT, BUSINESS_LINE, ZIP_CODE, TARIFF_CAT, ... | Tipo de dato a validar |
+| `fieldName` | string | sí | max 100 chars | Nombre del campo a validar |
+| `ruleType` | enum | sí | NOT_NULL, NOT_EMPTY, POSITIVE_NUMBER, FORMAT_REGEX, ENUM_VALUE, RANGE | Tipo de validación |
+| `parameters` | object | no | JSON con configuración de la regla | `{ pattern: "^[0-9]{5}$", minValue: 0, maxValue: null }` |
+| `errorMessage` | string | sí | max 500 chars | Mensaje de error personalizado |
+| `severity` | enum | sí | CRITICAL, WARNING, INFO | Severidad si la regla falla |
+| `enabled` | boolean | sí | true/false | Si la regla está activa |
+| `createdAt` | datetime (UTC) | sí | auto-generado | Timestamp creación de la regla |
+| `updatedAt` | datetime (UTC) | sí | auto-generado | Timestamp última actualización |
+| `createdBy` | string | sí | usuario o sistema que creó | Auditoría |
+
+#### Índices / Constraints
+
+- `data-inconsistencies`:
+  - Índice en `dataType, createdAt` (búsqueda de inconsistencias por tipo y fecha)
+  - Índice en `dataId` (búsqueda de inconsistencias de un registro específico)
+  - Índice en `status` (filtro por severidad)
+  - TTL index en `createdAt` con expiración 90 días (auto-limpieza de registros antiguos)
+
+- `validation-rules`:
+  - Índice único en `dataType, fieldName` (evitar reglas duplicadas)
+  - Índice en `enabled` (búsqueda de reglas activas)
+
+---
+
+### API Endpoints
+
+#### POST /api/v1/data-validation/validate
+- **Descripción**: Valida un lote de registros de datos maestros contra reglas de negocio
+- **Auth requerida**: sí (token interno o sistema-a-sistema)
+- **Request Body**:
+  ```json
+  {
+    "dataType": "SUBSCRIBER",
+    "records": [
+      { "id": "sub-001", "nombre": "Aseguradora ABC", "clave": "ABC", "activo": true }
+    ],
+    "correlationId": "req-123456"
+  }
+  ```
+- **Response 200**:
+  ```json
+  {
+    "totalRecords": 1,
+    "validRecords": 1,
+    "inconsistentRecords": 0,
+    "results": [
+      {
+        "id": "sub-001",
+        "status": "VALIDATED",
+        "errors": []
+      }
+    ]
+  }
+  ```
+- **Response 400**: `dataType` inválido o formato de request incorrecto
+- **Response 207 (Multi-Status)**: Validación parcial (algunos registros válidos, otros inválidos)
+  ```json
+  {
+    "totalRecords": 2,
+    "validRecords": 1,
+    "inconsistentRecords": 1,
+    "results": [
+      { "id": "sub-001", "status": "VALIDATED", "errors": [] },
+      { "id": "sub-002", "status": "INCONSISTENT", "errors": [{ "field": "nombre", "message": "Campo es obligatorio" }] }
+    ]
+  }
+  ```
+- **Response 500**: Error interno del servidor
+
+#### GET /api/v1/data-validation/inconsistencies
+- **Descripción**: Lista inconsistencias registradas con filtros opcionales
+- **Auth requerida**: sí
+- **Query Parameters**:
+  - `dataType` (opcional): SUBSCRIBER, TARIFF_CAT, etc.
+  - `status` (opcional): CRITICAL, WARNING, INFO
+  - `createdAfter` (opcional): timestamp ISO para filtrar por fecha
+  - `page` (opcional): número de página (default: 1)
+  - `size` (opcional): registros por página (default: 20)
+- **Response 200**:
+  ```json
+  {
+    "totalCount": 45,
+    "page": 1,
+    "size": 20,
+    "data": [
+      {
+        "id": "incons-uuid-001",
+        "dataType": "SUBSCRIBER",
+        "dataId": "sub-002",
+        "validationError": {
+          "field": "nombre",
+          "rule": "NOT_NULL",
+          "message": "Campo 'nombre' es obligatorio"
+        },
+        "status": "CRITICAL",
+        "createdAt": "2026-04-27T14:30:00Z"
+      }
+    ]
+  }
+  ```
+- **Response 401**: Sin autenticación
+
+#### GET /api/v1/data-validation/rules
+- **Descripción**: Lista todas las reglas de validación activas configuradas
+- **Auth requerida**: sí
+- **Query Parameters**:
+  - `dataType` (opcional): filtrar por tipo
+  - `enabled` (opcional): true/false
+- **Response 200**: Array de objetos `ValidationRule`
+- **Response 401**: Sin autenticación
+
+#### POST /api/v1/data-validation/rules (Admin only)
+- **Descripción**: Crea una nueva regla de validación
+- **Auth requerida**: sí (requiere rol ADMIN)
+- **Request Body**: Objeto `ValidationRule` (sin id, createdAt)
+- **Response 201**: Regla creada con id asignado
+- **Response 403**: Permiso denegado (no es admin)
+- **Response 400**: Validación de parámetros fallida
+
+#### PUT /api/v1/data-validation/rules/{ruleId} (Admin only)
+- **Descripción**: Actualiza una regla de validación
+- **Auth requerida**: sí (requiere rol ADMIN)
+- **Request Body**: Campos a actualizar
+- **Response 200**: Regla actualizada
+- **Response 404**: Regla no encontrada
+
+---
+
+### Componentes de Backend
+
+#### Service: `DataValidationService`
+
+```java
+public interface DataValidationService {
+    
+    // Validar un lote de registros
+    ValidationResult validateBatch(String dataType, List<Map<String, Object>> records, String correlationId);
+    
+    // Validar un registro individual
+    ValidationResult validateRecord(String dataType, Map<String, Object> record, String correlationId);
+    
+    // Obtener inconsistencias registradas
+    Page<DataInconsistency> getInconsistencies(
+        String dataType,
+        String status,
+        LocalDateTime createdAfter,
+        Pageable pageable
+    );
+    
+    // Resolver una inconsistencia manualmente
+    void resolveInconsistency(String inconsistencyId, String resolution);
+}
+```
+
+**Responsabilidades**:
+- Orquestar validación usando reglas configurables
+- Delegar a `DataValidationEngine` para aplicar reglas
+- Llamar a `DataInconsistencyRepository` para registrar errores
+- Registrar logs estructurados
+- Retornar resultados de validación
+
+#### Service: `DataValidationEngine`
+
+```java
+public interface DataValidationEngine {
+    
+    // Obtener reglas aplicables a un tipo de dato
+    List<ValidationRule> getRulesForDataType(String dataType);
+    
+    // Ejecutar una regla contra un valor
+    ValidationError applyRule(ValidationRule rule, String fieldName, Object value);
+}
+```
+
+**Responsabilidades**:
+- Aplicar reglas de validación específicas (NOT_NULL, POSITIVE_NUMBER, FORMAT_REGEX, etc.)
+- Retornar detalles del error si la validación falla
+- Ser altamente testeable y reutilizable
+
+#### Service: `DataCorrectionService` (HU-102)
+
+```java
+public interface DataCorrectionService {
+    
+    // Aplicar correcciones automáticas a un registro con inconsistencias
+    CorrectionResult applyCorrections(String dataType, Map<String, Object> record, List<ValidationError> errors);
+    
+    // Verificar si una inconsistencia tiene regla de corrección automática
+    boolean hasCorrectionRule(String dataType, String fieldName, String ruleType);
+}
+```
+
+**Responsabilidades**:
+- Aplicar correcciones conservadoras (TRIM, DEFAULT_VALUE, casing) a datos con inconsistencias simples
+- Preservar el valor original antes de corregir (`originalValue`)
+- Registrar la corrección aplicada en el log de inconsistencia
+
+#### Service: `InconsistencyNotificationService` (HU-103)
+
+```java
+public interface InconsistencyNotificationService {
+    
+    // Notificar una inconsistencia crítica individual
+    void notifyCritical(DataInconsistency inconsistency);
+    
+    // Emitir alerta cuando se supera el umbral del lote
+    void notifyBatchThresholdExceeded(int total, int inconsistentCount, String dataType);
+}
+```
+
+**Responsabilidades**:
+- Emitir log estructurado de nivel ERROR con detalles del registro de inconsistencia
+- Calcular si el % de inconsistencias en el lote supera el umbral configurable
+- No bloquear el flujo de procesamiento si la notificación falla (manejo de errores silencioso)
+
+#### Repository: `DataInconsistencyRepository`
+
+```java
+public interface DataInconsistencyRepository extends MongoRepository<DataInconsistency, String> {
+    
+    List<DataInconsistency> findByDataType(String dataType, Pageable pageable);
+    
+    List<DataInconsistency> findByStatus(String status, Pageable pageable);
+    
+    List<DataInconsistency> findByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+}
+```
+
+#### Repository: `ValidationRuleRepository`
+
+```java
+public interface ValidationRuleRepository extends MongoRepository<ValidationRule, String> {
+    
+    List<ValidationRule> findByDataTypeAndEnabled(String dataType, boolean enabled);
+    
+    Optional<ValidationRule> findByDataTypeAndFieldName(String dataType, String fieldName);
+}
+```
+
+#### Controller: `DataValidationController`
+
+```java
+@RestController
+@RequestMapping("/api/v1/data-validation")
+public class DataValidationController {
+    
+    @PostMapping("/validate")
+    public ResponseEntity<ValidationResult> validate(@Valid @RequestBody ValidationRequest request) { ... }
+    
+    @GetMapping("/inconsistencies")
+    public ResponseEntity<Page<DataInconsistency>> getInconsistencies(...) { ... }
+    
+    @GetMapping("/rules")
+    public ResponseEntity<List<ValidationRule>> getRules(...) { ... }
+    
+    @PostMapping("/rules")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ValidationRule> createRule(@Valid @RequestBody ValidationRule rule) { ... }
+    
+    @PutMapping("/rules/{ruleId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ValidationRule> updateRule(@PathVariable String ruleId, ...) { ... }
+}
+```
+
+#### DTOs
+
+- `ValidationRequest`: Entrada para validar un lote
+- `ValidationResult`: Resultado de validación con detalles por registro
+- `ValidationError`: Detalle de un error de validación
+- `DataInconsistencyResponse`: Representación de inconsistencia para API
+
+#### Configuración: `ValidationRulesConfig`
+
+- Beans para carga de reglas de validación desde MongoDB o archivo de configuración
+- Caché en memoria (Caffeine) con TTL configurable (default: 1 hora) para reglas
+- Invalidación manual de caché mediante endpoint admin
+
+---
+
+### Implementación de Validaciones
+
+#### Reglas incluidas en SPEC-007
+
+**Para Suscriptores (SUBSCRIBER)**:
+- `id`: NOT_NULL, NOT_EMPTY
+- `nombre`: NOT_NULL, NOT_EMPTY, max 255 chars
+- `clave`: NOT_NULL, NOT_EMPTY
+- `activo`: NOT_NULL
+
+**Para Agentes (AGENT)**:
+- `id`: NOT_NULL, NOT_EMPTY
+- `nombre`: NOT_NULL, NOT_EMPTY, max 255 chars
+- `clave`: NOT_NULL, NOT_EMPTY
+- `activo`: NOT_NULL
+
+**Para Giros (BUSINESS_LINE)**:
+- `id`: NOT_NULL, NOT_EMPTY
+- `nombre`: NOT_NULL, NOT_EMPTY, max 255 chars
+
+**Para Códigos Postales (ZIP_CODE)**:
+- `codigo`: NOT_NULL, FORMAT_REGEX (`^[0-9]{5}$`)
+- `ciudad`: NOT_NULL, NOT_EMPTY
+- `estado`: NOT_NULL, NOT_EMPTY
+
+**Para Tarifas CAT (TARIFF_CAT)**:
+- `zona`: NOT_NULL, NOT_EMPTY
+- `factorTEV`: POSITIVE_NUMBER (> 0), NUMERIC
+- `factorFHM`: POSITIVE_NUMBER (> 0), NUMERIC
+
+**Para Tarifas Fire (TARIFF_FIRE)**:
+- `factor`: POSITIVE_NUMBER (> 0), NUMERIC
+
+**Para Tarifas Electronic Equipment (TARIFF_ELECTRONIC_EQUIPMENT)**:
+- `factor`: POSITIVE_NUMBER (> 0), NUMERIC
+
+---
+
+### Arquitectura y Dependencias
+
+#### Paquetes nuevos requeridos
+
+```
+com.plataformas_danos_back
+├── validation/
+│   ├── service/
+│   │   ├── DataValidationService.java          (HU-100)
+│   │   ├── DataValidationServiceImpl.java
+│   │   ├── DataValidationEngine.java           (HU-100)
+│   │   ├── DataValidationEngineImpl.java
+│   │   ├── DataCorrectionService.java          (HU-102)
+│   │   ├── DataCorrectionServiceImpl.java
+│   │   ├── InconsistencyNotificationService.java  (HU-103)
+│   │   └── InconsistencyNotificationServiceImpl.java
+│   ├── controller/
+│   │   └── DataValidationController.java
+│   ├── repository/
+│   │   ├── DataInconsistencyRepository.java
+│   │   └── ValidationRuleRepository.java
+│   ├── model/
+│   │   ├── entity/
+│   │   │   ├── DataInconsistency.java
+│   │   │   ├── ValidationRule.java
+│   │   │   └── CorrectionRule.java             (HU-102, reglas de corrección automática)
+│   │   └── dto/
+│   │       ├── ValidationRequest.java
+│   │       ├── ValidationResult.java
+│   │       ├── ValidationError.java
+│   │       ├── CorrectionResult.java           (HU-102)
+│   │       └── DataInconsistencyResponse.java
+│   ├── config/
+│   │   ├── ValidationRulesConfig.java
+│   │   └── ValidationProperties.java          (HU-103, umbral configurable)
+│   └── exception/
+│       ├── ValidationException.java
+│       ├── InvalidRuleException.java
+│       └── InconsistencyRecordException.java
+```
+
+#### Dependencias Maven
+
+- Ya existentes en el proyecto:
+  - `spring-boot-starter-validation` (Bean Validation)
+  - `spring-boot-starter-data-mongodb`
+  - `spring-boot-starter-cache` (Caffeine)
+  - Lombok
+
+#### Integración en el ciclo de vida
+
+1. **Después de FT-015 a FT-018**: Cuando se reciben catálogos, tarifas y códigos postales, se ejecutan validaciones
+2. **Punto de integración**: En `CatalogsServiceImpl`, `TariffsServiceImpl`, `ZipCodeServiceImpl` — después de obtener datos de servicios externos, antes de exponer al frontend
+3. **Patrón**: Usar interceptor o decorator en servicios para validar automáticamente
+
+#### Ejemplo de integración
+
+```java
+@Service
+@RequiredArgsConstructor
+public class CatalogsServiceImpl implements CatalogsService {
+    
+    private final CatalogsClient catalogsClient;
+    private final DataValidationService validationService;
+    
+    @Override
+    public List<SubscriberDto> getSubscribers() {
+        // Obtener desde servicio externo
+        List<SubscriberDto> subscribers = catalogsClient.fetchSubscribers();
+        
+        // VALIDAR
+        ValidationResult result = validationService.validateBatch(
+            "SUBSCRIBER",
+            subscribers.stream().map(ObjectMapper::convertValue).collect(toList()),
+            MDC.get("correlationId")
+        );
+        
+        // Retornar solo registros VALIDATED
+        return subscribers.stream()
+            .filter(sub -> result.isValid(sub.getId()))
+            .collect(toList());
+    }
+}
+```
+
+---
+
+### Notas de Implementación
+
+> **Decisión de Diseño**: Las validaciones se ejecutan **de forma síncrona** inmediatamente después de recibir datos, no de forma asíncrona. Esto garantiza que los datos en caché del frontend siempre sean consistentes.
+
+> **Caché de Reglas**: Las reglas de validación se cargan una sola vez al iniciar la aplicación y se cachean en memoria (Caffeine TTL: 1 hora). Cambios en reglas requieren reiniciar la app o invalidación manual.
+
+> **Severidad vs. Bloqueo**: Inconsistencias de nivel `CRITICAL` o `ERROR` bloquean el uso del registro. Inconsistencias `WARNING` se registran pero permiten el procesamiento (según configuración).
+
+> **Extensibilidad**: El diseño usa un patrón Strategy para tipos de validación. Agregar nuevas validaciones requiere:
+>  1. Crear nueva clase implementando `ValidationRule`
+>  2. Registrarla en `ValidationRulesConfig`
+>  3. Agregar tests unitarios
+
+> **Auditoría**: Todos los registros de inconsistencias incluyen `correlationId` para correlacionar con requests originales en logs distribuidos.
+
+> **Impacto Frontal**: El frontend no verá datos inconsistentes. El backend filtra automáticamente registros con estado `INCONSISTENT` antes de retornarlos.
+
+---
+
+## 3. LISTA DE TAREAS
+
+> Checklist accionable para todos los agentes. Marcar cada ítem (`[x]`) al completarlo.
+> El Orchestrator monitorea este checklist para determinar el progreso.
+
+### Backend
+
+#### Implementación — HU-100: Validación
+
+- [x] Crear modelo `DataInconsistency` con anotación `@Document` en `model/entity/`
+- [x] Crear modelo `ValidationRule` con anotación `@Document` en `model/entity/`
+- [ ] Extender DTOs existentes (`SubscriberDto`, `TariffCatDto`, `ZipCodeDto`, etc.) con campo `dataStatus`
+- [x] Crear DTOs de Request/Response (`ValidationRequest`, `ValidationResult`, `ValidationError`, `DataInconsistencyResponse`) en `model/dto/`
+- [x] Implementar `DataInconsistencyRepository` — métodos CRUD y búsqueda por tipo/status/fecha
+- [x] Implementar `ValidationRuleRepository` — métodos de búsqueda y filtrado
+- [x] Implementar `DataValidationEngine` — motor para aplicar reglas individuales (NOT_NULL, POSITIVE_NUMBER, FORMAT_REGEX, etc.)
+- [x] Implementar `DataValidationService` — orquestador de validaciones y coordinador con repositorio
+- [x] Implementar `DataValidationController` — endpoints REST para validación, consulta de inconsistencias y gestión de reglas
+- [x] Crear `ValidationRulesConfig` — carga de reglas iniciales desde archivo o base de datos
+- [x] Crear excepciones custom en `exception/` (ValidationException, InvalidRuleException, InconsistencyRecordException)
+- [ ] Integrar validación en `CatalogsServiceImpl` — después de obtener suscriptores, agentes, giros
+- [ ] Integrar validación en `TariffsServiceImpl` — después de obtener tarifas CAT, Fire, Electronic Equipment
+- [ ] Integrar validación en `ZipCodeServiceImpl` — después de obtener códigos postales
+- [x] Configurar índices en MongoDB para colecciones `data-inconsistencies` y `validation-rules`
+- [x] Configurar TTL en `data-inconsistencies` (90 días)
+- [ ] Configurar caché Caffeine para `ValidationRule` con TTL 1 hora
+- [x] Registrar endpoint `/api/v1/data-validation/**` en punto de entrada de la app
+
+#### Implementación — HU-102: Corrección Automática
+
+- [x] Crear modelo `CorrectionRule` con anotación `@Document` en `model/entity/` — tipos: TRIM, DEFAULT_VALUE, NORMALIZE_CASE
+- [x] Crear DTO `CorrectionResult` con campos: `corrected` (boolean), `originalValue`, `correctedValue`, `ruleApplied`
+- [x] Implementar `DataCorrectionService` — aplica correcciones conservadoras (solo campos descriptivos/auxiliares, no clave)
+- [x] Implementar lógica de `hasCorrectionRule()` — verifica si existe regla de corrección para el campo/tipo de inconsistencia
+- [x] Guardar `originalValue` en el registro `DataInconsistency` cuando se aplica corrección
+- [x] Agregar campo `correctionApplied` y `correctionDetail` al modelo `DataInconsistency`
+- [x] Integrar `DataCorrectionService` en el flujo de `DataValidationService` (después de detectar inconsistencia, intentar corrección)
+
+#### Implementación — HU-103: Notificación
+
+- [x] Crear `ValidationProperties` — propiedades configurables en `application.yml`: `validation.inconsistency-threshold-percent` (default: 10)
+- [x] Implementar `InconsistencyNotificationService` — emite log ERROR estructurado con detalles de la inconsistencia crítica
+- [x] Implementar lógica de umbral de lote: si % inconsistencias > threshold → alerta de alto nivel
+- [x] Manejar fallo de notificación silenciosamente (try/catch + log) — no bloquear procesamiento principal
+- [x] Integrar `InconsistencyNotificationService` en `DataValidationService` al detectar inconsistencias CRITICAL
+
+#### Implementación — HU-104: Definición de Reglas
+
+- [x] Documentar catálogo inicial de `ValidationRule` en `ValidationRulesConfig` (reglas de HU-100 para todos los tipos de datos maestros)
+- [x] Documentar catálogo inicial de `CorrectionRule` (reglas TRIM para campos de texto, DEFAULT_VALUE para opcionales)
+- [x] Agregar endpoint `GET /api/v1/data-validation/rules` con filtro por `dataType` — para revisión por analistas
+- [x] Agregar seed/migration de reglas iniciales en MongoDB (o archivo de configuración YAML)
+
+#### Tests Backend
+
+- [ ] `test_validateSubscriber_validData_returnsValidated` — HU-100: suscriptor válido
+- [ ] `test_validateSubscriber_nullId_returnsInconsistent` — HU-100: id nulo
+- [ ] `test_validateSubscriber_emptyName_returnsInconsistent` — HU-100: nombre vacío
+- [ ] `test_validateTariffCat_validFactors_returnsValidated` — HU-100: tarifa válida
+- [ ] `test_validateTariffCat_negativeFactorTEV_returnsInconsistent` — HU-100: factor negativo
+- [ ] `test_validateTariffCat_zeroFactor_returnsInconsistent` — HU-100: factor = 0
+- [ ] `test_validateZipCode_validFormat_returnsValidated` — HU-100: código postal válido
+- [ ] `test_validateZipCode_invalidFormat_returnsInconsistent` — HU-100: formato incorrecto
+- [ ] `test_validateZipCode_nonNumeric_returnsInconsistent` — HU-100: caracteres no numéricos
+- [ ] `test_validateBatch_mixedRecords_returns207MultiStatus` — HU-100: lote parcial
+- [ ] `test_registerInconsistency_validData_persistsInMongoDB` — HU-101: persistencia
+- [ ] `test_getInconsistencies_byDataType_returnsFiltered` — HU-101: búsqueda por tipo
+- [ ] `test_getInconsistencies_byStatus_returnsFiltered` — HU-101: búsqueda por severidad
+- [ ] `test_dataValidationEngine_applyRule_NOT_NULL_detects` — HU-100: engine NOT_NULL
+- [ ] `test_dataValidationEngine_applyRule_POSITIVE_NUMBER_detects` — HU-100: engine positividad
+- [ ] `test_dataValidationEngine_applyRule_REGEX_detects` — HU-100: engine regex
+- [ ] `test_dataCorrectionService_trimSpaces_corrects` — HU-102: corrección TRIM
+- [ ] `test_dataCorrectionService_defaultValue_assignsDefault` — HU-102: DEFAULT_VALUE
+- [ ] `test_dataCorrectionService_preservesOriginalValue` — HU-102: auditoría valor original
+- [ ] `test_dataCorrectionService_noCorrectionRule_leavesInconsistent` — HU-102: sin regla aplicable
+- [ ] `test_notificationService_critical_emitsErrorLog` — HU-103: alerta inconsistencia crítica
+- [ ] `test_notificationService_batchThreshold_emitsHighLevelAlert` — HU-103: umbral de lote
+- [ ] `test_notificationService_failure_doesNotPropagateException` — HU-103: fallo silencioso
+- [ ] `test_catalogsService_getSubscribers_validatesAndFilters` — integración catalogs
+- [ ] `test_tariffsService_getTariffsCat_validatesAndFilters` — integración tarifas
+- [ ] `test_zipCodeService_getZipCodes_validatesAndFilters` — integración códigos postales
+- [ ] `test_controller_postValidate_returns200_success` — endpoint POST exitoso
+- [ ] `test_controller_postValidate_returns207_multiStatus` — endpoint POST con fallos parciales
+- [ ] `test_controller_getInconsistencies_returns200` — endpoint GET inconsistencias
+- [ ] `test_controller_getRules_returns200` — endpoint GET reglas
+- [ ] `test_controller_postRule_adminOnly_requires_authorization` — autorización admin
+- [ ] `test_validationRuleCache_expires_after_ttl` — invalidación caché
+- [ ] Cobertura global ≥ 80%, módulo validación ≥ 90%
+
+### Frontend
+
+#### Implementación
+
+- [ ] *(Sin cambios requeridos en frontend para SPEC-007)* — Validaciones son transparentes, ocurren en backend
+- [ ] *(Opcional para futuro)* Crear página `app/admin/validation-rules` para gestión de reglas (POST SPEC-007)
+- [ ] *(Opcional para futuro)* Crear página `app/admin/data-inconsistencies` para auditoría (POST SPEC-007)
+
+#### Tests Frontend
+
+- [ ] *(Sin tests frontend requeridos para SPEC-007)*
+
+### QA
+
+- [ ] Ejecutar skill `/gherkin-case-generator` contra criterios CRITERIO-100.1 a 100.8, CRITERIO-101.1 a 101.3, CRITERIO-102.1 a 102.4, CRITERIO-103.1 a 103.4, CRITERIO-104.1 a 104.3
+- [ ] Ejecutar skill `/risk-identifier` → clasificación ASD de riesgos de validación y consistencia
+- [ ] Validar cobertura de tests contra todos los criterios de aceptación
+- [ ] Verificar que todas las reglas de negocio (BR-001 a BR-006) están cubiertas en tests
+- [ ] Validar que logs estructurados JSON contienen `correlationId`, `timestamp`, `dataType`, `severity`
+- [ ] Pruebas de integración: Enviar datos inválidos vía mock server → verificar detección y registro
+- [ ] Pruebas de volumen: Enviar lote de 10,000 registros → verificar performance < 10 minutos
+- [ ] Validar que backend filtra registros inválidos antes de exponerlos al frontend
+- [ ] Pruebas de caché: Modificar una regla en MongoDB → verificar que se refleja en validaciones (invalidar manualmente o esperar 1 hora)
+- [ ] Validar retención de datos en MongoDB: Verificar que registros > 90 días se eliminan automáticamente (TTL)
+- [ ] Pruebas de autorización: Intentar crear/actualizar reglas sin rol ADMIN → verificar 403
+- [ ] Actualizar estado spec: `status: IMPLEMENTED` cuando todos los ítems estén marcados

--- a/.github/specs/ep-003-ft-021-core-validacion-datos.spec.md
+++ b/.github/specs/ep-003-ft-021-core-validacion-datos.spec.md
@@ -872,38 +872,38 @@ public class CatalogsServiceImpl implements CatalogsService {
 
 #### Tests Backend
 
-- [ ] `test_validateSubscriber_validData_returnsValidated` — HU-100: suscriptor válido
-- [ ] `test_validateSubscriber_nullId_returnsInconsistent` — HU-100: id nulo
-- [ ] `test_validateSubscriber_emptyName_returnsInconsistent` — HU-100: nombre vacío
-- [ ] `test_validateTariffCat_validFactors_returnsValidated` — HU-100: tarifa válida
-- [ ] `test_validateTariffCat_negativeFactorTEV_returnsInconsistent` — HU-100: factor negativo
-- [ ] `test_validateTariffCat_zeroFactor_returnsInconsistent` — HU-100: factor = 0
-- [ ] `test_validateZipCode_validFormat_returnsValidated` — HU-100: código postal válido
-- [ ] `test_validateZipCode_invalidFormat_returnsInconsistent` — HU-100: formato incorrecto
-- [ ] `test_validateZipCode_nonNumeric_returnsInconsistent` — HU-100: caracteres no numéricos
-- [ ] `test_validateBatch_mixedRecords_returns207MultiStatus` — HU-100: lote parcial
-- [ ] `test_registerInconsistency_validData_persistsInMongoDB` — HU-101: persistencia
-- [ ] `test_getInconsistencies_byDataType_returnsFiltered` — HU-101: búsqueda por tipo
-- [ ] `test_getInconsistencies_byStatus_returnsFiltered` — HU-101: búsqueda por severidad
-- [ ] `test_dataValidationEngine_applyRule_NOT_NULL_detects` — HU-100: engine NOT_NULL
-- [ ] `test_dataValidationEngine_applyRule_POSITIVE_NUMBER_detects` — HU-100: engine positividad
-- [ ] `test_dataValidationEngine_applyRule_REGEX_detects` — HU-100: engine regex
-- [ ] `test_dataCorrectionService_trimSpaces_corrects` — HU-102: corrección TRIM
-- [ ] `test_dataCorrectionService_defaultValue_assignsDefault` — HU-102: DEFAULT_VALUE
-- [ ] `test_dataCorrectionService_preservesOriginalValue` — HU-102: auditoría valor original
-- [ ] `test_dataCorrectionService_noCorrectionRule_leavesInconsistent` — HU-102: sin regla aplicable
-- [ ] `test_notificationService_critical_emitsErrorLog` — HU-103: alerta inconsistencia crítica
-- [ ] `test_notificationService_batchThreshold_emitsHighLevelAlert` — HU-103: umbral de lote
-- [ ] `test_notificationService_failure_doesNotPropagateException` — HU-103: fallo silencioso
-- [ ] `test_catalogsService_getSubscribers_validatesAndFilters` — integración catalogs
-- [ ] `test_tariffsService_getTariffsCat_validatesAndFilters` — integración tarifas
-- [ ] `test_zipCodeService_getZipCodes_validatesAndFilters` — integración códigos postales
-- [ ] `test_controller_postValidate_returns200_success` — endpoint POST exitoso
-- [ ] `test_controller_postValidate_returns207_multiStatus` — endpoint POST con fallos parciales
-- [ ] `test_controller_getInconsistencies_returns200` — endpoint GET inconsistencias
-- [ ] `test_controller_getRules_returns200` — endpoint GET reglas
-- [ ] `test_controller_postRule_adminOnly_requires_authorization` — autorización admin
-- [ ] `test_validationRuleCache_expires_after_ttl` — invalidación caché
+- [x] `test_validateSubscriber_validData_returnsValidated` — HU-100: suscriptor válido
+- [x] `test_validateSubscriber_nullId_returnsInconsistent` — HU-100: id nulo
+- [x] `test_validateSubscriber_emptyName_returnsInconsistent` — HU-100: nombre vacío
+- [x] `test_validateTariffCat_validFactors_returnsValidated` — HU-100: tarifa válida
+- [x] `test_validateTariffCat_negativeFactorTEV_returnsInconsistent` — HU-100: factor negativo
+- [x] `test_validateTariffCat_zeroFactor_returnsInconsistent` — HU-100: factor = 0
+- [x] `test_validateZipCode_validFormat_returnsValidated` — HU-100: código postal válido
+- [x] `test_validateZipCode_invalidFormat_returnsInconsistent` — HU-100: formato incorrecto
+- [x] `test_validateZipCode_nonNumeric_returnsInconsistent` — HU-100: caracteres no numéricos
+- [x] `test_validateBatch_mixedRecords_returns207MultiStatus` — HU-100: lote parcial
+- [x] `test_registerInconsistency_validData_persistsInMongoDB` — HU-101: persistencia
+- [x] `test_getInconsistencies_byDataType_returnsFiltered` — HU-101: búsqueda por tipo
+- [x] `test_getInconsistencies_byStatus_returnsFiltered` — HU-101: búsqueda por severidad
+- [x] `test_dataValidationEngine_applyRule_NOT_NULL_detects` — HU-100: engine NOT_NULL
+- [x] `test_dataValidationEngine_applyRule_POSITIVE_NUMBER_detects` — HU-100: engine positividad
+- [x] `test_dataValidationEngine_applyRule_REGEX_detects` — HU-100: engine regex
+- [x] `test_dataCorrectionService_trimSpaces_corrects` — HU-102: corrección TRIM
+- [x] `test_dataCorrectionService_defaultValue_assignsDefault` — HU-102: DEFAULT_VALUE
+- [x] `test_dataCorrectionService_preservesOriginalValue` — HU-102: auditoría valor original
+- [x] `test_dataCorrectionService_noCorrectionRule_leavesInconsistent` — HU-102: sin regla aplicable
+- [x] `test_notificationService_critical_emitsErrorLog` — HU-103: alerta inconsistencia crítica
+- [x] `test_notificationService_batchThreshold_emitsHighLevelAlert` — HU-103: umbral de lote
+- [x] `test_notificationService_failure_doesNotPropagateException` — HU-103: fallo silencioso
+- [ ] `test_catalogsService_getSubscribers_validatesAndFilters` — integración catalogs (pendiente: integración no implementada)
+- [ ] `test_tariffsService_getTariffsCat_validatesAndFilters` — integración tarifas (pendiente: integración no implementada)
+- [ ] `test_zipCodeService_getZipCodes_validatesAndFilters` — integración códigos postales (pendiente: integración no implementada)
+- [x] `test_controller_postValidate_returns200_success` — endpoint POST exitoso
+- [x] `test_controller_postValidate_returns207_multiStatus` — endpoint POST con fallos parciales
+- [x] `test_controller_getInconsistencies_returns200` — endpoint GET inconsistencias
+- [x] `test_controller_getRules_returns200` — endpoint GET reglas
+- [ ] `test_controller_postRule_adminOnly_requires_authorization` — autorización admin (endpoint no implementado aún)
+- [ ] `test_validationRuleCache_expires_after_ttl` — invalidación caché (pendiente: cache no configurado)
 - [ ] Cobertura global ≥ 80%, módulo validación ≥ 90%
 
 ### Frontend

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/MongoConfig.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/MongoConfig.java
@@ -1,0 +1,47 @@
+package com.plataformas_danos_back.config;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@Configuration
+public class MongoConfig {
+
+    @Value("${spring.data.mongodb.host:localhost}")
+    private String host;
+
+    @Value("${spring.data.mongodb.port:27017}")
+    private int port;
+
+    @Value("${spring.data.mongodb.database:plataformas_danos}")
+    private String database;
+
+    @Value("${spring.data.mongodb.username:admin}")
+    private String username;
+
+    @Value("${spring.data.mongodb.password:admin}")
+    private String password;
+
+    @Value("${spring.data.mongodb.authentication-database:admin}")
+    private String authDatabase;
+
+    @Bean
+    public MongoClient mongoClient() {
+        String uri = String.format("mongodb://%s:%s@%s:%d/%s?authSource=%s",
+                username, password, host, port, database, authDatabase);
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(new ConnectionString(uri))
+                .build();
+        return MongoClients.create(settings);
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
+        return new MongoTemplate(mongoClient, database);
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/ValidationProperties.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/ValidationProperties.java
@@ -1,0 +1,13 @@
+package com.plataformas_danos_back.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "validation")
+@Data
+public class ValidationProperties {
+
+    private int inconsistencyThresholdPercent = 10;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/ValidationRulesConfig.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/config/ValidationRulesConfig.java
@@ -1,0 +1,163 @@
+package com.plataformas_danos_back.config;
+
+import com.plataformas_danos_back.model.entity.CorrectionRule;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import com.plataformas_danos_back.repository.CorrectionRuleRepository;
+import com.plataformas_danos_back.repository.ValidationRuleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class ValidationRulesConfig {
+
+    private static final String SYSTEM = "system";
+    private static final String CRITICAL = "CRITICAL";
+    private static final String WARNING = "WARNING";
+
+    private final ValidationRuleRepository validationRuleRepository;
+    private final CorrectionRuleRepository correctionRuleRepository;
+
+    @Bean
+    public CommandLineRunner seedValidationRules() {
+        return args -> {
+            if (validationRuleRepository.count() == 0) {
+                log.info("Cargando catálogo inicial de reglas de validación...");
+                validationRuleRepository.saveAll(buildInitialValidationRules());
+                log.info("Reglas de validación cargadas exitosamente.");
+            }
+            if (correctionRuleRepository.count() == 0) {
+                log.info("Cargando catálogo inicial de reglas de corrección...");
+                correctionRuleRepository.saveAll(buildInitialCorrectionRules());
+                log.info("Reglas de corrección cargadas exitosamente.");
+            }
+        };
+    }
+
+    private List<ValidationRule> buildInitialValidationRules() {
+        Instant now = Instant.now();
+        return List.of(
+                // ── SUBSCRIBER ──────────────────────────────────────────────
+                rule("SUBSCRIBER", "id", "NOT_NULL", null,
+                        "Campo 'id' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("SUBSCRIBER", "id", "NOT_EMPTY", null,
+                        "Campo 'id' no puede estar vacío", CRITICAL, now),
+                rule("SUBSCRIBER", "nombre", "NOT_NULL", null,
+                        "Campo 'nombre' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("SUBSCRIBER", "nombre", "NOT_EMPTY", null,
+                        "Campo 'nombre' no puede estar vacío", CRITICAL, now),
+                rule("SUBSCRIBER", "clave", "NOT_NULL", null,
+                        "Campo 'clave' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("SUBSCRIBER", "clave", "NOT_EMPTY", null,
+                        "Campo 'clave' no puede estar vacío", CRITICAL, now),
+                rule("SUBSCRIBER", "activo", "NOT_NULL", null,
+                        "Campo 'activo' es obligatorio y no puede ser nulo", CRITICAL, now),
+
+                // ── AGENT ────────────────────────────────────────────────────
+                rule("AGENT", "id", "NOT_NULL", null,
+                        "Campo 'id' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("AGENT", "id", "NOT_EMPTY", null,
+                        "Campo 'id' no puede estar vacío", CRITICAL, now),
+                rule("AGENT", "nombre", "NOT_NULL", null,
+                        "Campo 'nombre' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("AGENT", "nombre", "NOT_EMPTY", null,
+                        "Campo 'nombre' no puede estar vacío", CRITICAL, now),
+                rule("AGENT", "clave", "NOT_NULL", null,
+                        "Campo 'clave' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("AGENT", "clave", "NOT_EMPTY", null,
+                        "Campo 'clave' no puede estar vacío", CRITICAL, now),
+                rule("AGENT", "activo", "NOT_NULL", null,
+                        "Campo 'activo' es obligatorio y no puede ser nulo", CRITICAL, now),
+
+                // ── BUSINESS_LINE ────────────────────────────────────────────
+                rule("BUSINESS_LINE", "id", "NOT_NULL", null,
+                        "Campo 'id' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("BUSINESS_LINE", "id", "NOT_EMPTY", null,
+                        "Campo 'id' no puede estar vacío", CRITICAL, now),
+                rule("BUSINESS_LINE", "nombre", "NOT_NULL", null,
+                        "Campo 'nombre' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("BUSINESS_LINE", "nombre", "NOT_EMPTY", null,
+                        "Campo 'nombre' no puede estar vacío", CRITICAL, now),
+
+                // ── ZIP_CODE ─────────────────────────────────────────────────
+                rule("ZIP_CODE", "codigo", "NOT_NULL", null,
+                        "Campo 'codigo' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("ZIP_CODE", "codigo", "FORMAT_REGEX",
+                        Map.of("pattern", "^[0-9]{5}$"),
+                        "Código postal debe contener exactamente 5 dígitos numéricos", CRITICAL, now),
+                rule("ZIP_CODE", "ciudad", "NOT_NULL", null,
+                        "Campo 'ciudad' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("ZIP_CODE", "ciudad", "NOT_EMPTY", null,
+                        "Campo 'ciudad' no puede estar vacío", CRITICAL, now),
+                rule("ZIP_CODE", "estado", "NOT_NULL", null,
+                        "Campo 'estado' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("ZIP_CODE", "estado", "NOT_EMPTY", null,
+                        "Campo 'estado' no puede estar vacío", CRITICAL, now),
+
+                // ── TARIFF_CAT ───────────────────────────────────────────────
+                rule("TARIFF_CAT", "zona", "NOT_NULL", null,
+                        "Campo 'zona' es obligatorio y no puede ser nulo", CRITICAL, now),
+                rule("TARIFF_CAT", "zona", "NOT_EMPTY", null,
+                        "Campo 'zona' no puede estar vacío", CRITICAL, now),
+                rule("TARIFF_CAT", "factorTEV", "POSITIVE_NUMBER", null,
+                        "Campo 'factorTEV' debe ser un número positivo (>0)", CRITICAL, now),
+                rule("TARIFF_CAT", "factorFHM", "POSITIVE_NUMBER", null,
+                        "Campo 'factorFHM' debe ser un número positivo (>0)", CRITICAL, now),
+
+                // ── TARIFF_FIRE ──────────────────────────────────────────────
+                rule("TARIFF_FIRE", "factor", "POSITIVE_NUMBER", null,
+                        "Campo 'factor' debe ser un número positivo (>0)", CRITICAL, now),
+
+                // ── TARIFF_ELECTRONIC ────────────────────────────────────────
+                rule("TARIFF_ELECTRONIC", "factor", "POSITIVE_NUMBER", null,
+                        "Campo 'factor' debe ser un número positivo (>0)", CRITICAL, now)
+        );
+    }
+
+    private List<CorrectionRule> buildInitialCorrectionRules() {
+        return List.of(
+                // TRIM en campos descriptivos de texto — no aplica sobre campos clave
+                correctionRule("SUBSCRIBER", "nombre", "TRIM", null),
+                correctionRule("AGENT", "nombre", "TRIM", null),
+                correctionRule("BUSINESS_LINE", "nombre", "TRIM", null),
+                correctionRule("ZIP_CODE", "ciudad", "TRIM", null),
+                correctionRule("ZIP_CODE", "estado", "TRIM", null)
+        );
+    }
+
+    private ValidationRule rule(String dataType, String fieldName, String ruleType,
+                                 Map<String, Object> parameters, String errorMessage,
+                                 String severity, Instant now) {
+        return ValidationRule.builder()
+                .dataType(dataType)
+                .fieldName(fieldName)
+                .ruleType(ruleType)
+                .parameters(parameters)
+                .errorMessage(errorMessage)
+                .severity(severity)
+                .enabled(true)
+                .createdAt(now)
+                .updatedAt(now)
+                .createdBy(SYSTEM)
+                .build();
+    }
+
+    private CorrectionRule correctionRule(String dataType, String fieldName,
+                                           String correctionType, Object defaultValue) {
+        return CorrectionRule.builder()
+                .dataType(dataType)
+                .fieldName(fieldName)
+                .correctionType(correctionType)
+                .defaultValue(defaultValue)
+                .enabled(true)
+                .build();
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/controller/DataValidationController.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/controller/DataValidationController.java
@@ -1,0 +1,77 @@
+package com.plataformas_danos_back.controller;
+
+import com.plataformas_danos_back.model.dto.ValidationRequest;
+import com.plataformas_danos_back.model.dto.ValidationResult;
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import com.plataformas_danos_back.repository.ValidationRuleRepository;
+import com.plataformas_danos_back.service.DataValidationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/data-validation")
+public class DataValidationController {
+
+    private final DataValidationService dataValidationService;
+    private final ValidationRuleRepository validationRuleRepository;
+
+    @PostMapping("/validate")
+    public ResponseEntity<ValidationResult> validate(@Valid @RequestBody ValidationRequest request) {
+        ValidationResult result = dataValidationService.validateBatch(
+                request.getDataType(),
+                request.getRecords(),
+                request.getCorrelationId()
+        );
+
+        if (result.getInconsistentRecords() > 0) {
+            return ResponseEntity.status(HttpStatus.MULTI_STATUS).body(result);
+        }
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/inconsistencies")
+    public ResponseEntity<Page<DataInconsistency>> getInconsistencies(
+            @RequestParam(required = false) String dataType,
+            @RequestParam(required = false) String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        int clampedSize = Math.min(size, 100);
+        Pageable pageable = PageRequest.of(page, clampedSize);
+        Page<DataInconsistency> result = dataValidationService.getInconsistencies(dataType, status, pageable);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/rules")
+    public ResponseEntity<List<ValidationRule>> getRules(
+            @RequestParam(required = false) String dataType,
+            @RequestParam(required = false) Boolean enabled) {
+
+        List<ValidationRule> rules;
+        if (dataType != null && enabled != null) {
+            rules = validationRuleRepository.findByDataTypeAndEnabled(dataType, enabled);
+        } else if (dataType != null) {
+            rules = validationRuleRepository.findByDataType(dataType);
+        } else if (enabled != null) {
+            rules = validationRuleRepository.findByEnabled(enabled);
+        } else {
+            rules = validationRuleRepository.findAll();
+        }
+        return ResponseEntity.ok(rules);
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/GlobalExceptionHandler.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/GlobalExceptionHandler.java
@@ -2,11 +2,13 @@ package com.plataformas_danos_back.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -42,5 +44,32 @@ public class GlobalExceptionHandler {
                         "message", "El servicio externo retornó un error: " + ex.getStatusCode(),
                         "code", "EXTERNAL_CLIENT_ERROR"
                 ));
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<Map<String, String>> handleValidationException(ValidationException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", ex.getMessage(), "code", "VALIDATION_ERROR"));
+    }
+
+    @ExceptionHandler(InvalidRuleException.class)
+    public ResponseEntity<Map<String, String>> handleInvalidRule(InvalidRuleException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", ex.getMessage(), "code", "INVALID_RULE"));
+    }
+
+    @ExceptionHandler(InconsistencyRecordException.class)
+    public ResponseEntity<Map<String, String>> handleInconsistencyRecord(InconsistencyRecordException ex) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(Map.of("message", ex.getMessage(), "code", "INCONSISTENCY_RECORD_ERROR"));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(fe -> fe.getField() + ": " + fe.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Map.of("message", message, "code", "INVALID_REQUEST"));
     }
 }

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/InconsistencyRecordException.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/InconsistencyRecordException.java
@@ -1,0 +1,12 @@
+package com.plataformas_danos_back.exception;
+
+public class InconsistencyRecordException extends RuntimeException {
+
+    public InconsistencyRecordException(String message) {
+        super(message);
+    }
+
+    public InconsistencyRecordException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/InvalidRuleException.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/InvalidRuleException.java
@@ -1,0 +1,12 @@
+package com.plataformas_danos_back.exception;
+
+public class InvalidRuleException extends RuntimeException {
+
+    public InvalidRuleException(String message) {
+        super(message);
+    }
+
+    public InvalidRuleException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/ValidationException.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/exception/ValidationException.java
@@ -1,0 +1,12 @@
+package com.plataformas_danos_back.exception;
+
+public class ValidationException extends RuntimeException {
+
+    public ValidationException(String message) {
+        super(message);
+    }
+
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/CorrectionResult.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/CorrectionResult.java
@@ -1,0 +1,18 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CorrectionResult {
+
+    private boolean corrected;
+    private Object originalValue;
+    private Object correctedValue;
+    private String ruleApplied;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/DataInconsistencyResponse.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/DataInconsistencyResponse.java
@@ -1,0 +1,26 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DataInconsistencyResponse {
+
+    private String id;
+    private String dataType;
+    private String dataId;
+    private ValidationErrorDetail validationError;
+    private String status;
+    private String correlationId;
+    private Instant createdAt;
+    private Instant resolvedAt;
+    private String resolution;
+    private boolean correctionApplied;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/ValidationErrorDetail.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/ValidationErrorDetail.java
@@ -1,0 +1,18 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationErrorDetail {
+
+    private String field;
+    private String rule;
+    private String message;
+    private String severity;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/ValidationRequest.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/ValidationRequest.java
@@ -1,0 +1,26 @@
+package com.plataformas_danos_back.model.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationRequest {
+
+    @NotBlank(message = "El campo dataType es obligatorio")
+    private String dataType;
+
+    @NotEmpty(message = "La lista de registros no puede estar vacía")
+    private List<Map<String, Object>> records;
+
+    private String correlationId;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/ValidationResult.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/dto/ValidationResult.java
@@ -1,0 +1,32 @@
+package com.plataformas_danos_back.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ValidationResult {
+
+    private int totalRecords;
+    private int validRecords;
+    private int inconsistentRecords;
+    private List<RecordValidationResult> results;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RecordValidationResult {
+        private String id;
+        private String status;
+        private List<ValidationErrorDetail> errors;
+        @Builder.Default
+        private boolean correctionApplied = false;
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/entity/CorrectionRule.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/entity/CorrectionRule.java
@@ -1,0 +1,35 @@
+package com.plataformas_danos_back.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "correction-rules")
+@CompoundIndexes({
+        @CompoundIndex(name = "idx_dataType_fieldName_enabled", def = "{'dataType': 1, 'fieldName': 1, 'enabled': 1}")
+})
+public class CorrectionRule {
+
+    @Id
+    private String id;
+
+    private String dataType;
+
+    private String fieldName;
+
+    private String correctionType;
+
+    private Object defaultValue;
+
+    @Builder.Default
+    private boolean enabled = true;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/entity/DataInconsistency.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/entity/DataInconsistency.java
@@ -1,0 +1,76 @@
+package com.plataformas_danos_back.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "data-inconsistencies")
+@CompoundIndexes({
+        @CompoundIndex(name = "idx_dataType_createdAt", def = "{'dataType': 1, 'createdAt': -1}"),
+        @CompoundIndex(name = "idx_dataType_status", def = "{'dataType': 1, 'status': 1}")
+})
+public class DataInconsistency {
+
+    @Id
+    private String id;
+
+    private String dataType;
+
+    @Indexed
+    private String dataId;
+
+    private Map<String, Object> value;
+
+    private ValidationErrorDetail validationError;
+
+    @Indexed
+    private String status;
+
+    private String correlationId;
+
+    @Indexed(expireAfterSeconds = 7776000) // 90 días TTL
+    private Instant createdAt;
+
+    private Instant resolvedAt;
+
+    private String resolution;
+
+    @Builder.Default
+    private boolean correctionApplied = false;
+
+    private CorrectionDetail correctionDetail;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ValidationErrorDetail {
+        private String field;
+        private String rule;
+        private String message;
+        private String severity;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CorrectionDetail {
+        private Object originalValue;
+        private Object correctedValue;
+        private String ruleApplied;
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/entity/ValidationRule.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/model/entity/ValidationRule.java
@@ -1,0 +1,50 @@
+package com.plataformas_danos_back.model.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.index.CompoundIndexes;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "validation-rules")
+@CompoundIndexes({
+        @CompoundIndex(name = "idx_dataType_fieldName_unique", def = "{'dataType': 1, 'fieldName': 1}", unique = true)
+})
+public class ValidationRule {
+
+    @Id
+    private String id;
+
+    private String dataType;
+
+    private String fieldName;
+
+    private String ruleType;
+
+    private Map<String, Object> parameters;
+
+    private String errorMessage;
+
+    private String severity;
+
+    @Indexed
+    @Builder.Default
+    private boolean enabled = true;
+
+    private Instant createdAt;
+
+    private Instant updatedAt;
+
+    private String createdBy;
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/repository/CorrectionRuleRepository.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/repository/CorrectionRuleRepository.java
@@ -1,0 +1,14 @@
+package com.plataformas_danos_back.repository;
+
+import com.plataformas_danos_back.model.entity.CorrectionRule;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CorrectionRuleRepository extends MongoRepository<CorrectionRule, String> {
+
+    Optional<CorrectionRule> findByDataTypeAndFieldNameAndEnabled(String dataType, String fieldName, boolean enabled);
+
+    List<CorrectionRule> findByDataTypeAndEnabled(String dataType, boolean enabled);
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/repository/DataInconsistencyRepository.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/repository/DataInconsistencyRepository.java
@@ -1,0 +1,25 @@
+package com.plataformas_danos_back.repository;
+
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface DataInconsistencyRepository extends MongoRepository<DataInconsistency, String> {
+
+    List<DataInconsistency> findByDataType(String dataType);
+
+    List<DataInconsistency> findByStatus(String status);
+
+    List<DataInconsistency> findByDataTypeAndStatus(String dataType, String status);
+
+    Page<DataInconsistency> findAll(Pageable pageable);
+
+    Page<DataInconsistency> findByDataType(String dataType, Pageable pageable);
+
+    Page<DataInconsistency> findByStatus(String status, Pageable pageable);
+
+    Page<DataInconsistency> findByDataTypeAndStatus(String dataType, String status, Pageable pageable);
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/repository/ValidationRuleRepository.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/repository/ValidationRuleRepository.java
@@ -1,0 +1,18 @@
+package com.plataformas_danos_back.repository;
+
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ValidationRuleRepository extends MongoRepository<ValidationRule, String> {
+
+    List<ValidationRule> findByDataTypeAndEnabled(String dataType, boolean enabled);
+
+    Optional<ValidationRule> findByDataTypeAndFieldName(String dataType, String fieldName);
+
+    List<ValidationRule> findByEnabled(boolean enabled);
+
+    List<ValidationRule> findByDataType(String dataType);
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataCorrectionService.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataCorrectionService.java
@@ -1,0 +1,10 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.dto.CorrectionResult;
+
+public interface DataCorrectionService {
+
+    CorrectionResult applyCorrection(String dataType, String fieldName, Object value);
+
+    boolean hasCorrectionRule(String dataType, String fieldName);
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataCorrectionServiceImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataCorrectionServiceImpl.java
@@ -1,0 +1,60 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.dto.CorrectionResult;
+import com.plataformas_danos_back.model.entity.CorrectionRule;
+import com.plataformas_danos_back.repository.CorrectionRuleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataCorrectionServiceImpl implements DataCorrectionService {
+
+    private final CorrectionRuleRepository correctionRuleRepository;
+
+    @Override
+    public CorrectionResult applyCorrection(String dataType, String fieldName, Object value) {
+        Optional<CorrectionRule> ruleOpt =
+                correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled(dataType, fieldName, true);
+
+        if (ruleOpt.isEmpty()) {
+            return CorrectionResult.builder()
+                    .corrected(false)
+                    .originalValue(value)
+                    .build();
+        }
+
+        CorrectionRule rule = ruleOpt.get();
+        Object correctedValue = applyCorrectionType(rule, value);
+
+        return CorrectionResult.builder()
+                .corrected(true)
+                .originalValue(value)
+                .correctedValue(correctedValue)
+                .ruleApplied(rule.getCorrectionType())
+                .build();
+    }
+
+    @Override
+    public boolean hasCorrectionRule(String dataType, String fieldName) {
+        return correctionRuleRepository
+                .findByDataTypeAndFieldNameAndEnabled(dataType, fieldName, true)
+                .isPresent();
+    }
+
+    private Object applyCorrectionType(CorrectionRule rule, Object value) {
+        return switch (rule.getCorrectionType()) {
+            case "TRIM" -> value != null ? value.toString().trim() : null;
+            case "DEFAULT_VALUE" -> rule.getDefaultValue();
+            case "NORMALIZE_CASE" -> value != null ? value.toString().toUpperCase() : null;
+            default -> {
+                log.warn("Tipo de corrección no reconocido: {}", rule.getCorrectionType());
+                yield value;
+            }
+        };
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationEngine.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationEngine.java
@@ -1,0 +1,13 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.dto.ValidationErrorDetail;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+
+import java.util.List;
+
+public interface DataValidationEngine {
+
+    List<ValidationRule> getRulesForDataType(String dataType);
+
+    ValidationErrorDetail applyRule(ValidationRule rule, Object value);
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationEngineImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationEngineImpl.java
@@ -1,0 +1,74 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.dto.ValidationErrorDetail;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import com.plataformas_danos_back.repository.ValidationRuleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataValidationEngineImpl implements DataValidationEngine {
+
+    private final ValidationRuleRepository validationRuleRepository;
+
+    @Override
+    public List<ValidationRule> getRulesForDataType(String dataType) {
+        return validationRuleRepository.findByDataTypeAndEnabled(dataType, true);
+    }
+
+    @Override
+    public ValidationErrorDetail applyRule(ValidationRule rule, Object value) {
+        boolean violated = switch (rule.getRuleType()) {
+            case "NOT_NULL" -> value == null;
+            case "NOT_EMPTY" -> value == null || value.toString().isBlank();
+            case "POSITIVE_NUMBER" -> isNotPositiveNumber(rule, value);
+            case "FORMAT_REGEX" -> isNotMatchingRegex(rule, value);
+            default -> {
+                log.warn("Tipo de regla no reconocido: {}", rule.getRuleType());
+                yield false;
+            }
+        };
+
+        if (!violated) {
+            return null;
+        }
+
+        return ValidationErrorDetail.builder()
+                .field(rule.getFieldName())
+                .rule(rule.getRuleType())
+                .message(rule.getErrorMessage())
+                .severity(rule.getSeverity())
+                .build();
+    }
+
+    private boolean isNotPositiveNumber(ValidationRule rule, Object value) {
+        if (value == null) {
+            return true;
+        }
+        try {
+            double number = Double.parseDouble(value.toString());
+            return number <= 0;
+        } catch (NumberFormatException ex) {
+            log.warn("Error de esquema en campo '{}': se esperaba numérico, se recibió '{}'",
+                    rule.getFieldName(), value);
+            return true;
+        }
+    }
+
+    private boolean isNotMatchingRegex(ValidationRule rule, Object value) {
+        if (value == null) {
+            return true;
+        }
+        Object patternObj = rule.getParameters() != null ? rule.getParameters().get("pattern") : null;
+        if (patternObj == null) {
+            log.warn("Regla FORMAT_REGEX para campo '{}' no tiene parámetro 'pattern'", rule.getFieldName());
+            return false;
+        }
+        return !value.toString().matches(patternObj.toString());
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationService.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationService.java
@@ -1,0 +1,16 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.dto.ValidationResult;
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Map;
+
+public interface DataValidationService {
+
+    ValidationResult validateBatch(String dataType, List<Map<String, Object>> records, String correlationId);
+
+    Page<DataInconsistency> getInconsistencies(String dataType, String status, Pageable pageable);
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationServiceImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/DataValidationServiceImpl.java
@@ -1,0 +1,222 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.config.ValidationProperties;
+import com.plataformas_danos_back.model.dto.CorrectionResult;
+import com.plataformas_danos_back.model.dto.ValidationErrorDetail;
+import com.plataformas_danos_back.model.dto.ValidationResult;
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import com.plataformas_danos_back.repository.DataInconsistencyRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DataValidationServiceImpl implements DataValidationService {
+
+    private static final String STATUS_VALIDATED = "VALIDATED";
+    private static final String STATUS_INCONSISTENT = "INCONSISTENT";
+    private static final String SEVERITY_CRITICAL = "CRITICAL";
+
+    private final DataValidationEngine dataValidationEngine;
+    private final DataCorrectionService dataCorrectionService;
+    private final InconsistencyNotificationService notificationService;
+    private final DataInconsistencyRepository inconsistencyRepository;
+    private final ValidationProperties validationProperties;
+
+    @Override
+    public ValidationResult validateBatch(String dataType, List<Map<String, Object>> records, String correlationId) {
+        List<ValidationResult.RecordValidationResult> results = new ArrayList<>();
+        int inconsistentCount = 0;
+
+        List<ValidationRule> rules = dataValidationEngine.getRulesForDataType(dataType);
+
+        for (Map<String, Object> record : records) {
+            String recordId = resolveRecordId(record);
+            ValidationResult.RecordValidationResult result = processRecord(dataType, record, recordId, rules, correlationId);
+            results.add(result);
+            if (STATUS_INCONSISTENT.equals(result.getStatus())) {
+                inconsistentCount++;
+            }
+        }
+
+        int total = records.size();
+        int validCount = total - inconsistentCount;
+
+        checkBatchThreshold(total, inconsistentCount, dataType);
+
+        return ValidationResult.builder()
+                .totalRecords(total)
+                .validRecords(validCount)
+                .inconsistentRecords(inconsistentCount)
+                .results(results)
+                .build();
+    }
+
+    @Override
+    public Page<DataInconsistency> getInconsistencies(String dataType, String status, Pageable pageable) {
+        if (dataType != null && status != null) {
+            return inconsistencyRepository.findByDataTypeAndStatus(dataType, status, pageable);
+        }
+        if (dataType != null) {
+            return inconsistencyRepository.findByDataType(dataType, pageable);
+        }
+        if (status != null) {
+            return inconsistencyRepository.findByStatus(status, pageable);
+        }
+        return inconsistencyRepository.findAll(pageable);
+    }
+
+    private ValidationResult.RecordValidationResult processRecord(
+            String dataType,
+            Map<String, Object> record,
+            String recordId,
+            List<ValidationRule> rules,
+            String correlationId) {
+
+        List<ValidationErrorDetail> errors = collectErrors(rules, record);
+
+        if (errors.isEmpty()) {
+            return ValidationResult.RecordValidationResult.builder()
+                    .id(recordId)
+                    .status(STATUS_VALIDATED)
+                    .errors(List.of())
+                    .build();
+        }
+
+        return attemptCorrection(dataType, record, recordId, errors, correlationId);
+    }
+
+    private List<ValidationErrorDetail> collectErrors(List<ValidationRule> rules, Map<String, Object> record) {
+        List<ValidationErrorDetail> errors = new ArrayList<>();
+        for (ValidationRule rule : rules) {
+            Object fieldValue = record.get(rule.getFieldName());
+            ValidationErrorDetail error = dataValidationEngine.applyRule(rule, fieldValue);
+            if (error != null) {
+                errors.add(error);
+            }
+        }
+        return errors;
+    }
+
+    private ValidationResult.RecordValidationResult attemptCorrection(
+            String dataType,
+            Map<String, Object> record,
+            String recordId,
+            List<ValidationErrorDetail> errors,
+            String correlationId) {
+
+        List<ValidationErrorDetail> uncorrectedErrors = new ArrayList<>();
+        DataInconsistency.CorrectionDetail correctionDetail = null;
+        boolean anyCorrected = false;
+
+        for (ValidationErrorDetail error : errors) {
+            if (dataCorrectionService.hasCorrectionRule(dataType, error.getField())) {
+                Object originalValue = record.get(error.getField());
+                CorrectionResult correction = dataCorrectionService.applyCorrection(dataType, error.getField(), originalValue);
+                if (correction.isCorrected()) {
+                    record.put(error.getField(), correction.getCorrectedValue());
+                    anyCorrected = true;
+                    correctionDetail = DataInconsistency.CorrectionDetail.builder()
+                            .originalValue(correction.getOriginalValue())
+                            .correctedValue(correction.getCorrectedValue())
+                            .ruleApplied(correction.getRuleApplied())
+                            .build();
+                    log.info("Corrección automática aplicada: dataType={}, field={}, rule={}",
+                            dataType, error.getField(), correction.getRuleApplied());
+                    continue;
+                }
+            }
+            uncorrectedErrors.add(error);
+        }
+
+        if (uncorrectedErrors.isEmpty()) {
+            return ValidationResult.RecordValidationResult.builder()
+                    .id(recordId)
+                    .status(STATUS_VALIDATED)
+                    .errors(List.of())
+                    .correctionApplied(true)
+                    .build();
+        }
+
+        DataInconsistency saved = persistInconsistency(
+                dataType, recordId, record, uncorrectedErrors.get(0), correlationId, anyCorrected, correctionDetail);
+
+        if (SEVERITY_CRITICAL.equals(uncorrectedErrors.get(0).getSeverity())) {
+            notificationService.notifyCritical(saved);
+        }
+
+        return ValidationResult.RecordValidationResult.builder()
+                .id(recordId)
+                .status(STATUS_INCONSISTENT)
+                .errors(uncorrectedErrors)
+                .correctionApplied(anyCorrected)
+                .build();
+    }
+
+    private DataInconsistency persistInconsistency(
+            String dataType,
+            String dataId,
+            Map<String, Object> record,
+            ValidationErrorDetail primaryError,
+            String correlationId,
+            boolean correctionApplied,
+            DataInconsistency.CorrectionDetail correctionDetail) {
+
+        DataInconsistency inconsistency = DataInconsistency.builder()
+                .id(UUID.randomUUID().toString())
+                .dataType(dataType)
+                .dataId(dataId)
+                .value(record)
+                .validationError(DataInconsistency.ValidationErrorDetail.builder()
+                        .field(primaryError.getField())
+                        .rule(primaryError.getRule())
+                        .message(primaryError.getMessage())
+                        .severity(primaryError.getSeverity())
+                        .build())
+                .status(primaryError.getSeverity())
+                .correlationId(correlationId)
+                .createdAt(Instant.now())
+                .correctionApplied(correctionApplied)
+                .correctionDetail(correctionDetail)
+                .build();
+
+        try {
+            return inconsistencyRepository.save(inconsistency);
+        } catch (Exception ex) {
+            log.error("PERSISTENCE_ERROR al guardar inconsistencia dataType={} dataId={}: {}",
+                    dataType, dataId, ex.getMessage());
+            return inconsistency;
+        }
+    }
+
+    private void checkBatchThreshold(int total, int inconsistentCount, String dataType) {
+        if (total == 0) {
+            return;
+        }
+        double percent = (inconsistentCount * 100.0) / total;
+        if (percent > validationProperties.getInconsistencyThresholdPercent()) {
+            notificationService.notifyBatchThresholdExceeded(total, inconsistentCount, dataType);
+        }
+    }
+
+    private String resolveRecordId(Map<String, Object> record) {
+        for (String candidate : List.of("id", "codigo", "zona", "clase")) {
+            Object val = record.get(candidate);
+            if (val != null && !val.toString().isBlank()) {
+                return val.toString();
+            }
+        }
+        return UUID.randomUUID().toString();
+    }
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/InconsistencyNotificationService.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/InconsistencyNotificationService.java
@@ -1,0 +1,10 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+
+public interface InconsistencyNotificationService {
+
+    void notifyCritical(DataInconsistency inconsistency);
+
+    void notifyBatchThresholdExceeded(int total, int inconsistentCount, String dataType);
+}

--- a/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/InconsistencyNotificationServiceImpl.java
+++ b/plataformas-danos-back/src/main/java/com/plataformas_danos_back/service/InconsistencyNotificationServiceImpl.java
@@ -1,0 +1,67 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.config.ValidationProperties;
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InconsistencyNotificationServiceImpl implements InconsistencyNotificationService {
+
+    private final ValidationProperties validationProperties;
+
+    @Override
+    public void notifyCritical(DataInconsistency inconsistency) {
+        try {
+            String field = inconsistency.getValidationError() != null
+                    ? inconsistency.getValidationError().getField()
+                    : "desconocido";
+            String rule = inconsistency.getValidationError() != null
+                    ? inconsistency.getValidationError().getRule()
+                    : "desconocido";
+
+            log.error(
+                    "{{\"event\":\"CRITICAL_INCONSISTENCY\","
+                    + "\"inconsistencyId\":\"{}\","
+                    + "\"dataType\":\"{}\","
+                    + "\"dataId\":\"{}\","
+                    + "\"field\":\"{}\","
+                    + "\"rule\":\"{}\","
+                    + "\"correlationId\":\"{}\"}}",
+                    inconsistency.getId(),
+                    inconsistency.getDataType(),
+                    inconsistency.getDataId(),
+                    field,
+                    rule,
+                    inconsistency.getCorrelationId()
+            );
+        } catch (Exception ex) {
+            log.error("Fallo al notificar inconsistencia crítica id={}: {}", inconsistency.getId(), ex.getMessage());
+        }
+    }
+
+    @Override
+    public void notifyBatchThresholdExceeded(int total, int inconsistentCount, String dataType) {
+        try {
+            double percent = total > 0 ? (inconsistentCount * 100.0) / total : 0.0;
+            String percentFormatted = String.format("%.2f", percent);
+            log.error(
+                    "{{\"event\":\"BATCH_THRESHOLD_EXCEEDED\","
+                    + "\"dataType\":\"{}\","
+                    + "\"totalRecords\":{},\"inconsistentRecords\":{},"
+                    + "\"inconsistencyPercent\":{},"
+                    + "\"thresholdPercent\":{}}}",
+                    dataType,
+                    total,
+                    inconsistentCount,
+                    percentFormatted,
+                    validationProperties.getInconsistencyThresholdPercent()
+            );
+        } catch (Exception ex) {
+            log.error("Fallo al notificar umbral de lote dataType={}: {}", dataType, ex.getMessage());
+        }
+    }
+}

--- a/plataformas-danos-back/src/main/resources/application.yaml
+++ b/plataformas-danos-back/src/main/resources/application.yaml
@@ -3,7 +3,12 @@ spring:
     name: plataformas-danos-back
   data:
     mongodb:
-      uri: ${MONGODB_URI:mongodb://localhost:27017/plataformas_danos}
+      host: ${MONGODB_HOST:localhost}
+      port: ${MONGODB_PORT:27017}
+      database: ${MONGODB_DATABASE:plataformas_danos}
+      username: ${MONGODB_USERNAME:admin}
+      password: ${MONGODB_PASSWORD:admin}
+      authentication-database: ${MONGODB_AUTH_DATABASE:admin}
   cache:
     type: caffeine
     caffeine:
@@ -26,6 +31,9 @@ jwt:
 plataforma-core-ohs:
   url: ${PLATAFORMA_CORE_OHS_URL:http://localhost:3001}
   timeout-ms: ${PLATAFORMA_CORE_OHS_TIMEOUT_MS:5000}
+
+validation:
+  inconsistency-threshold-percent: ${VALIDATION_INCONSISTENCY_THRESHOLD_PERCENT:10}
 
 resilience4j:
   circuitbreaker:

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/controller/DataValidationControllerTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/controller/DataValidationControllerTest.java
@@ -1,0 +1,289 @@
+package com.plataformas_danos_back.controller;
+
+import com.plataformas_danos_back.model.dto.ValidationRequest;
+import com.plataformas_danos_back.model.dto.ValidationResult;
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import com.plataformas_danos_back.repository.ValidationRuleRepository;
+import com.plataformas_danos_back.service.DataValidationService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataValidationControllerTest {
+
+    @Mock
+    private DataValidationService dataValidationService;
+
+    @Mock
+    private ValidationRuleRepository validationRuleRepository;
+
+    @InjectMocks
+    private DataValidationController controller;
+
+    // ── POST /validate — 200 OK (todos válidos) ───────────────────────────
+
+    @Test
+    void validate_allRecordsValid_returns200() {
+        // GIVEN
+        var request = ValidationRequest.builder()
+                .dataType("SUBSCRIBER")
+                .records(List.of(Map.of("id", "sub-001", "nombre", "Aseg ABC")))
+                .correlationId("corr-001")
+                .build();
+        var validResult = ValidationResult.builder()
+                .totalRecords(1)
+                .validRecords(1)
+                .inconsistentRecords(0)
+                .results(List.of(
+                        ValidationResult.RecordValidationResult.builder()
+                                .id("sub-001")
+                                .status("VALIDATED")
+                                .errors(List.of())
+                                .build()
+                ))
+                .build();
+        when(dataValidationService.validateBatch("SUBSCRIBER", request.getRecords(), "corr-001"))
+                .thenReturn(validResult);
+
+        // WHEN
+        var response = controller.validate(request);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getInconsistentRecords()).isEqualTo(0);
+        assertThat(response.getBody().getValidRecords()).isEqualTo(1);
+    }
+
+    @Test
+    void validate_allRecordsValid_delegatesToService() {
+        // GIVEN
+        var request = ValidationRequest.builder()
+                .dataType("TARIFF_CAT")
+                .records(List.of(Map.of("zona", "ZONA_A", "factorTEV", 0.0015)))
+                .correlationId("corr-002")
+                .build();
+        var result = ValidationResult.builder()
+                .totalRecords(1).validRecords(1).inconsistentRecords(0).results(List.of()).build();
+        when(dataValidationService.validateBatch(anyString(), any(), anyString())).thenReturn(result);
+
+        // WHEN
+        controller.validate(request);
+
+        // THEN
+        verify(dataValidationService).validateBatch("TARIFF_CAT", request.getRecords(), "corr-002");
+    }
+
+    // ── POST /validate — 207 Multi-Status (parcialmente inválidos) ────────
+
+    @Test
+    void validate_someRecordsInvalid_returns207() {
+        // GIVEN
+        var request = ValidationRequest.builder()
+                .dataType("SUBSCRIBER")
+                .records(List.of(
+                        Map.of("id", "sub-001", "nombre", "Aseg ABC"),
+                        Map.<String, Object>of("id", "sub-002")
+                ))
+                .correlationId("corr-003")
+                .build();
+        var mixedResult = ValidationResult.builder()
+                .totalRecords(2)
+                .validRecords(1)
+                .inconsistentRecords(1)
+                .results(List.of())
+                .build();
+        when(dataValidationService.validateBatch(anyString(), any(), anyString()))
+                .thenReturn(mixedResult);
+
+        // WHEN
+        var response = controller.validate(request);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.MULTI_STATUS);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getInconsistentRecords()).isEqualTo(1);
+    }
+
+    @Test
+    void validate_allRecordsInvalid_returns207() {
+        // GIVEN
+        var request = ValidationRequest.builder()
+                .dataType("SUBSCRIBER")
+                .records(List.of(Map.<String, Object>of("id", "sub-001")))
+                .correlationId("corr-004")
+                .build();
+        var invalidResult = ValidationResult.builder()
+                .totalRecords(1)
+                .validRecords(0)
+                .inconsistentRecords(1)
+                .results(List.of())
+                .build();
+        when(dataValidationService.validateBatch(anyString(), any(), anyString()))
+                .thenReturn(invalidResult);
+
+        // WHEN
+        var response = controller.validate(request);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.MULTI_STATUS);
+    }
+
+    // ── GET /inconsistencies ──────────────────────────────────────────────
+
+    @Test
+    void getInconsistencies_noFilters_returns200WithPage() {
+        // GIVEN
+        var inconsistency = DataInconsistency.builder()
+                .id("uuid-001")
+                .dataType("SUBSCRIBER")
+                .dataId("sub-002")
+                .status("CRITICAL")
+                .createdAt(Instant.now())
+                .build();
+        var page = new PageImpl<>(List.of(inconsistency));
+        when(dataValidationService.getInconsistencies(eq(null), eq(null), any()))
+                .thenReturn(page);
+
+        // WHEN
+        var response = controller.getInconsistencies(null, null, 0, 20);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getContent()).hasSize(1);
+    }
+
+    @Test
+    void getInconsistencies_withFilters_delegatesFiltersToService() {
+        // GIVEN
+        var page = new PageImpl<DataInconsistency>(List.of());
+        when(dataValidationService.getInconsistencies(eq("SUBSCRIBER"), eq("CRITICAL"), any()))
+                .thenReturn(page);
+
+        // WHEN
+        controller.getInconsistencies("SUBSCRIBER", "CRITICAL", 0, 20);
+
+        // THEN
+        verify(dataValidationService).getInconsistencies(eq("SUBSCRIBER"), eq("CRITICAL"), any());
+    }
+
+    @Test
+    void getInconsistencies_sizeExceedsMax_clampsTo100() {
+        // GIVEN
+        var page = new PageImpl<DataInconsistency>(List.of());
+        when(dataValidationService.getInconsistencies(any(), any(), any())).thenReturn(page);
+
+        // WHEN
+        controller.getInconsistencies(null, null, 0, 500);
+
+        // THEN — tamaño se limita a 100
+        verify(dataValidationService).getInconsistencies(
+                any(), any(), eq(PageRequest.of(0, 100)));
+    }
+
+    // ── GET /rules ────────────────────────────────────────────────────────
+
+    @Test
+    void getRules_dataTypeAndEnabled_callsCorrectRepositoryMethod() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "id", "NOT_NULL");
+        when(validationRuleRepository.findByDataTypeAndEnabled("SUBSCRIBER", true))
+                .thenReturn(List.of(rule));
+
+        // WHEN
+        var response = controller.getRules("SUBSCRIBER", true);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(1);
+        assertThat(response.getBody().get(0).getDataType()).isEqualTo("SUBSCRIBER");
+        verify(validationRuleRepository).findByDataTypeAndEnabled("SUBSCRIBER", true);
+    }
+
+    @Test
+    void getRules_onlyDataType_callsFindByDataType() {
+        // GIVEN
+        when(validationRuleRepository.findByDataType("TARIFF_CAT")).thenReturn(List.of());
+
+        // WHEN
+        controller.getRules("TARIFF_CAT", null);
+
+        // THEN
+        verify(validationRuleRepository).findByDataType("TARIFF_CAT");
+    }
+
+    @Test
+    void getRules_onlyEnabled_callsFindByEnabled() {
+        // GIVEN
+        when(validationRuleRepository.findByEnabled(true)).thenReturn(List.of());
+
+        // WHEN
+        controller.getRules(null, true);
+
+        // THEN
+        verify(validationRuleRepository).findByEnabled(true);
+    }
+
+    @Test
+    void getRules_noFilters_callsFindAll() {
+        // GIVEN
+        when(validationRuleRepository.findAll()).thenReturn(List.of());
+
+        // WHEN
+        var response = controller.getRules(null, null);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        verify(validationRuleRepository).findAll();
+    }
+
+    @Test
+    void getRules_returns200WithRuleList() {
+        // GIVEN
+        var rules = List.of(
+                buildRule("SUBSCRIBER", "id", "NOT_NULL"),
+                buildRule("SUBSCRIBER", "nombre", "NOT_EMPTY")
+        );
+        when(validationRuleRepository.findByDataType("SUBSCRIBER")).thenReturn(rules);
+
+        // WHEN
+        var response = controller.getRules("SUBSCRIBER", null);
+
+        // THEN
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).hasSize(2);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private ValidationRule buildRule(String dataType, String fieldName, String ruleType) {
+        return ValidationRule.builder()
+                .dataType(dataType)
+                .fieldName(fieldName)
+                .ruleType(ruleType)
+                .errorMessage("Error en campo '" + fieldName + "'")
+                .severity("CRITICAL")
+                .enabled(true)
+                .build();
+    }
+}

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/DataCorrectionServiceImplTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/DataCorrectionServiceImplTest.java
@@ -1,0 +1,206 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.entity.CorrectionRule;
+import com.plataformas_danos_back.repository.CorrectionRuleRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataCorrectionServiceImplTest {
+
+    @Mock
+    private CorrectionRuleRepository correctionRuleRepository;
+
+    @InjectMocks
+    private DataCorrectionServiceImpl service;
+
+    // ── applyCorrection — sin regla ───────────────────────────────────────
+
+    @Test
+    void applyCorrection_noRuleExists_returnsCorrectedFalse() {
+        // GIVEN
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("SUBSCRIBER", "nombre", true))
+                .thenReturn(Optional.empty());
+
+        // WHEN
+        var result = service.applyCorrection("SUBSCRIBER", "nombre", "  Valor  ");
+
+        // THEN
+        assertThat(result.isCorrected()).isFalse();
+        assertThat(result.getOriginalValue()).isEqualTo("  Valor  ");
+        assertThat(result.getCorrectedValue()).isNull();
+        assertThat(result.getRuleApplied()).isNull();
+    }
+
+    // ── applyCorrection — TRIM ────────────────────────────────────────────
+
+    @Test
+    void applyCorrection_trimRule_removesLeadingTrailingSpaces() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "TRIM", null);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("SUBSCRIBER", "nombre", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        var result = service.applyCorrection("SUBSCRIBER", "nombre", "  Aseguradora ABC  ");
+
+        // THEN
+        assertThat(result.isCorrected()).isTrue();
+        assertThat(result.getOriginalValue()).isEqualTo("  Aseguradora ABC  ");
+        assertThat(result.getCorrectedValue()).isEqualTo("Aseguradora ABC");
+        assertThat(result.getRuleApplied()).isEqualTo("TRIM");
+    }
+
+    @Test
+    void applyCorrection_trimRule_nullValue_returnsNull() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "TRIM", null);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("SUBSCRIBER", "nombre", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        var result = service.applyCorrection("SUBSCRIBER", "nombre", null);
+
+        // THEN
+        assertThat(result.isCorrected()).isTrue();
+        assertThat(result.getCorrectedValue()).isNull();
+    }
+
+    // ── applyCorrection — DEFAULT_VALUE ───────────────────────────────────
+
+    @Test
+    void applyCorrection_defaultValueRule_assignsConfiguredDefault() {
+        // GIVEN
+        var rule = buildRule("AGENT", "activo", "DEFAULT_VALUE", true);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("AGENT", "activo", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        var result = service.applyCorrection("AGENT", "activo", null);
+
+        // THEN
+        assertThat(result.isCorrected()).isTrue();
+        assertThat(result.getOriginalValue()).isNull();
+        assertThat(result.getCorrectedValue()).isEqualTo(true);
+        assertThat(result.getRuleApplied()).isEqualTo("DEFAULT_VALUE");
+    }
+
+    // ── applyCorrection — NORMALIZE_CASE ──────────────────────────────────
+
+    @Test
+    void applyCorrection_normalizeCaseRule_convertsToUpperCase() {
+        // GIVEN
+        var rule = buildRule("BUSINESS_LINE", "nombre", "NORMALIZE_CASE", null);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("BUSINESS_LINE", "nombre", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        var result = service.applyCorrection("BUSINESS_LINE", "nombre", "comercial minorista");
+
+        // THEN
+        assertThat(result.isCorrected()).isTrue();
+        assertThat(result.getOriginalValue()).isEqualTo("comercial minorista");
+        assertThat(result.getCorrectedValue()).isEqualTo("COMERCIAL MINORISTA");
+        assertThat(result.getRuleApplied()).isEqualTo("NORMALIZE_CASE");
+    }
+
+    @Test
+    void applyCorrection_normalizeCaseRule_nullValue_returnsNull() {
+        // GIVEN
+        var rule = buildRule("BUSINESS_LINE", "nombre", "NORMALIZE_CASE", null);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("BUSINESS_LINE", "nombre", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        var result = service.applyCorrection("BUSINESS_LINE", "nombre", null);
+
+        // THEN
+        assertThat(result.isCorrected()).isTrue();
+        assertThat(result.getCorrectedValue()).isNull();
+    }
+
+    // ── applyCorrection — preserva valorOriginal ──────────────────────────
+
+    @Test
+    void applyCorrection_trimRule_preservesOriginalValue() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "TRIM", null);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("SUBSCRIBER", "nombre", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        var result = service.applyCorrection("SUBSCRIBER", "nombre", "  Original  ");
+
+        // THEN
+        assertThat(result.getOriginalValue()).isEqualTo("  Original  ");
+        assertThat(result.getCorrectedValue()).isEqualTo("Original");
+    }
+
+    // ── hasCorrectionRule ─────────────────────────────────────────────────
+
+    @Test
+    void hasCorrectionRule_ruleExists_returnsTrue() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "TRIM", null);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("SUBSCRIBER", "nombre", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        boolean exists = service.hasCorrectionRule("SUBSCRIBER", "nombre");
+
+        // THEN
+        assertThat(exists).isTrue();
+        verify(correctionRuleRepository).findByDataTypeAndFieldNameAndEnabled("SUBSCRIBER", "nombre", true);
+    }
+
+    @Test
+    void hasCorrectionRule_ruleNotExists_returnsFalse() {
+        // GIVEN
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("TARIFF_CAT", "zona", true))
+                .thenReturn(Optional.empty());
+
+        // WHEN
+        boolean exists = service.hasCorrectionRule("TARIFF_CAT", "zona");
+
+        // THEN
+        assertThat(exists).isFalse();
+    }
+
+    // ── applyCorrection — tipo de corrección desconocido ─────────────────
+
+    @Test
+    void applyCorrection_unknownCorrectionType_returnsSameValue() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "TIPO_DESCONOCIDO", null);
+        when(correctionRuleRepository.findByDataTypeAndFieldNameAndEnabled("SUBSCRIBER", "nombre", true))
+                .thenReturn(Optional.of(rule));
+
+        // WHEN
+        var result = service.applyCorrection("SUBSCRIBER", "nombre", "valor");
+
+        // THEN
+        assertThat(result.isCorrected()).isTrue();
+        assertThat(result.getCorrectedValue()).isEqualTo("valor");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private CorrectionRule buildRule(String dataType, String fieldName, String correctionType, Object defaultValue) {
+        return CorrectionRule.builder()
+                .dataType(dataType)
+                .fieldName(fieldName)
+                .correctionType(correctionType)
+                .defaultValue(defaultValue)
+                .enabled(true)
+                .build();
+    }
+}

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/DataValidationEngineImplTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/DataValidationEngineImplTest.java
@@ -1,0 +1,337 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.model.dto.ValidationErrorDetail;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import com.plataformas_danos_back.repository.ValidationRuleRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataValidationEngineImplTest {
+
+    @Mock
+    private ValidationRuleRepository validationRuleRepository;
+
+    @InjectMocks
+    private DataValidationEngineImpl engine;
+
+    // ── getRulesForDataType ───────────────────────────────────────────────
+
+    @Test
+    void getRulesForDataType_existingType_returnsEnabledRules() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "id", "NOT_NULL", null, "CRITICAL");
+        when(validationRuleRepository.findByDataTypeAndEnabled("SUBSCRIBER", true))
+                .thenReturn(List.of(rule));
+
+        // WHEN
+        var result = engine.getRulesForDataType("SUBSCRIBER");
+
+        // THEN
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getDataType()).isEqualTo("SUBSCRIBER");
+        verify(validationRuleRepository).findByDataTypeAndEnabled("SUBSCRIBER", true);
+    }
+
+    @Test
+    void getRulesForDataType_unknownType_returnsEmptyList() {
+        // GIVEN
+        when(validationRuleRepository.findByDataTypeAndEnabled("UNKNOWN", true))
+                .thenReturn(List.of());
+
+        // WHEN
+        var result = engine.getRulesForDataType("UNKNOWN");
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    // ── applyRule — NOT_NULL ──────────────────────────────────────────────
+
+    @Test
+    void applyRule_notNull_nullValue_returnsError() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "id", "NOT_NULL", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, null);
+
+        // THEN
+        assertThat(error).isNotNull();
+        assertThat(error.getField()).isEqualTo("id");
+        assertThat(error.getRule()).isEqualTo("NOT_NULL");
+        assertThat(error.getSeverity()).isEqualTo("CRITICAL");
+    }
+
+    @Test
+    void applyRule_notNull_validValue_returnsNull() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "id", "NOT_NULL", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "sub-001");
+
+        // THEN
+        assertThat(error).isNull();
+    }
+
+    // ── applyRule — NOT_EMPTY ─────────────────────────────────────────────
+
+    @Test
+    void applyRule_notEmpty_nullValue_returnsError() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_EMPTY", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, null);
+
+        // THEN
+        assertThat(error).isNotNull();
+        assertThat(error.getField()).isEqualTo("nombre");
+        assertThat(error.getRule()).isEqualTo("NOT_EMPTY");
+    }
+
+    @Test
+    void applyRule_notEmpty_blankString_returnsError() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_EMPTY", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "   ");
+
+        // THEN
+        assertThat(error).isNotNull();
+        assertThat(error.getRule()).isEqualTo("NOT_EMPTY");
+    }
+
+    @Test
+    void applyRule_notEmpty_emptyString_returnsError() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_EMPTY", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "");
+
+        // THEN
+        assertThat(error).isNotNull();
+    }
+
+    @Test
+    void applyRule_notEmpty_validString_returnsNull() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_EMPTY", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "Aseguradora XYZ");
+
+        // THEN
+        assertThat(error).isNull();
+    }
+
+    // ── applyRule — POSITIVE_NUMBER ───────────────────────────────────────
+
+    @Test
+    void applyRule_positiveNumber_nullValue_returnsError() {
+        // GIVEN
+        var rule = buildRule("TARIFF_CAT", "factorTEV", "POSITIVE_NUMBER", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, null);
+
+        // THEN
+        assertThat(error).isNotNull();
+        assertThat(error.getRule()).isEqualTo("POSITIVE_NUMBER");
+    }
+
+    @Test
+    void applyRule_positiveNumber_zeroValue_returnsError() {
+        // GIVEN
+        var rule = buildRule("TARIFF_CAT", "factorTEV", "POSITIVE_NUMBER", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, 0.0);
+
+        // THEN
+        assertThat(error).isNotNull();
+    }
+
+    @Test
+    void applyRule_positiveNumber_negativeValue_returnsError() {
+        // GIVEN
+        var rule = buildRule("TARIFF_CAT", "factorTEV", "POSITIVE_NUMBER", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, -1.5);
+
+        // THEN
+        assertThat(error).isNotNull();
+    }
+
+    @Test
+    void applyRule_positiveNumber_nonNumericString_returnsError() {
+        // GIVEN
+        var rule = buildRule("TARIFF_CAT", "factorTEV", "POSITIVE_NUMBER", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "no-es-numero");
+
+        // THEN
+        assertThat(error).isNotNull();
+    }
+
+    @Test
+    void applyRule_positiveNumber_validPositiveValue_returnsNull() {
+        // GIVEN
+        var rule = buildRule("TARIFF_CAT", "factorTEV", "POSITIVE_NUMBER", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, 0.0015);
+
+        // THEN
+        assertThat(error).isNull();
+    }
+
+    @Test
+    void applyRule_positiveNumber_positiveStringValue_returnsNull() {
+        // GIVEN
+        var rule = buildRule("TARIFF_CAT", "factorFHM", "POSITIVE_NUMBER", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "0.0008");
+
+        // THEN
+        assertThat(error).isNull();
+    }
+
+    // ── applyRule — FORMAT_REGEX ──────────────────────────────────────────
+
+    @Test
+    void applyRule_formatRegex_nullValue_returnsError() {
+        // GIVEN
+        var rule = buildRule("ZIP_CODE", "codigo", "FORMAT_REGEX",
+                Map.of("pattern", "^[0-9]{5}$"), "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, null);
+
+        // THEN
+        assertThat(error).isNotNull();
+        assertThat(error.getRule()).isEqualTo("FORMAT_REGEX");
+    }
+
+    @Test
+    void applyRule_formatRegex_invalidFormat_returnsError() {
+        // GIVEN
+        var rule = buildRule("ZIP_CODE", "codigo", "FORMAT_REGEX",
+                Map.of("pattern", "^[0-9]{5}$"), "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "1234X");
+
+        // THEN
+        assertThat(error).isNotNull();
+        assertThat(error.getField()).isEqualTo("codigo");
+    }
+
+    @Test
+    void applyRule_formatRegex_tooShort_returnsError() {
+        // GIVEN
+        var rule = buildRule("ZIP_CODE", "codigo", "FORMAT_REGEX",
+                Map.of("pattern", "^[0-9]{5}$"), "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "1234");
+
+        // THEN
+        assertThat(error).isNotNull();
+    }
+
+    @Test
+    void applyRule_formatRegex_validFormat_returnsNull() {
+        // GIVEN
+        var rule = buildRule("ZIP_CODE", "codigo", "FORMAT_REGEX",
+                Map.of("pattern", "^[0-9]{5}$"), "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "06600");
+
+        // THEN
+        assertThat(error).isNull();
+    }
+
+    @Test
+    void applyRule_formatRegex_missingPatternParameter_returnsNull() {
+        // GIVEN — regla FORMAT_REGEX sin parámetro 'pattern': se considera pasada por seguridad
+        var rule = buildRule("ZIP_CODE", "codigo", "FORMAT_REGEX", null, "CRITICAL");
+
+        // WHEN
+        var error = engine.applyRule(rule, "06600");
+
+        // THEN
+        assertThat(error).isNull();
+    }
+
+    // ── applyRule — tipo desconocido ──────────────────────────────────────
+
+    @Test
+    void applyRule_unknownRuleType_returnsNull() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "UNKNOWN_TYPE", null, "WARNING");
+
+        // WHEN
+        var error = engine.applyRule(rule, "cualquier valor");
+
+        // THEN — no reconocida: yield false → no violada → null
+        assertThat(error).isNull();
+    }
+
+    // ── applyRule — mapeo de campos en ValidationErrorDetail ─────────────
+
+    @Test
+    void applyRule_violation_mapsAllFieldsInError() {
+        // GIVEN
+        var rule = ValidationRule.builder()
+                .dataType("SUBSCRIBER")
+                .fieldName("nombre")
+                .ruleType("NOT_NULL")
+                .errorMessage("Campo 'nombre' es obligatorio")
+                .severity("CRITICAL")
+                .enabled(true)
+                .build();
+
+        // WHEN
+        ValidationErrorDetail error = engine.applyRule(rule, null);
+
+        // THEN
+        assertThat(error).isNotNull();
+        assertThat(error.getField()).isEqualTo("nombre");
+        assertThat(error.getRule()).isEqualTo("NOT_NULL");
+        assertThat(error.getMessage()).isEqualTo("Campo 'nombre' es obligatorio");
+        assertThat(error.getSeverity()).isEqualTo("CRITICAL");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private ValidationRule buildRule(String dataType, String fieldName, String ruleType,
+                                     Map<String, Object> parameters, String severity) {
+        return ValidationRule.builder()
+                .dataType(dataType)
+                .fieldName(fieldName)
+                .ruleType(ruleType)
+                .parameters(parameters)
+                .errorMessage("Error en campo '" + fieldName + "'")
+                .severity(severity)
+                .enabled(true)
+                .build();
+    }
+}

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/DataValidationServiceImplTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/DataValidationServiceImplTest.java
@@ -1,0 +1,404 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.config.ValidationProperties;
+import com.plataformas_danos_back.model.dto.CorrectionResult;
+import com.plataformas_danos_back.model.dto.ValidationErrorDetail;
+import com.plataformas_danos_back.model.dto.ValidationResult;
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import com.plataformas_danos_back.model.entity.ValidationRule;
+import com.plataformas_danos_back.repository.DataInconsistencyRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DataValidationServiceImplTest {
+
+    @Mock
+    private DataValidationEngine dataValidationEngine;
+    @Mock
+    private DataCorrectionService dataCorrectionService;
+    @Mock
+    private InconsistencyNotificationService notificationService;
+    @Mock
+    private DataInconsistencyRepository inconsistencyRepository;
+    @Mock
+    private ValidationProperties validationProperties;
+
+    @InjectMocks
+    private DataValidationServiceImpl service;
+
+    // ── validateBatch — Happy Path ────────────────────────────────────────
+
+    @Test
+    void validateBatch_allRecordsValid_returnsAllValidated() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_NULL", "CRITICAL");
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(eq(rule), any())).thenReturn(null);
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(
+                Map.<String, Object>of("id", "sub-001", "nombre", "Aseguradora ABC"),
+                Map.<String, Object>of("id", "sub-002", "nombre", "Aseguradora XYZ")
+        );
+
+        // WHEN
+        ValidationResult result = service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN
+        assertThat(result.getTotalRecords()).isEqualTo(2);
+        assertThat(result.getValidRecords()).isEqualTo(2);
+        assertThat(result.getInconsistentRecords()).isEqualTo(0);
+        assertThat(result.getResults()).allMatch(r -> "VALIDATED".equals(r.getStatus()));
+    }
+
+    @Test
+    void validateBatch_allRecordsInvalid_returnsAllInconsistent() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_NULL", "CRITICAL");
+        var errorDetail = buildError("nombre", "NOT_NULL", "CRITICAL");
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(eq(rule), any())).thenReturn(errorDetail);
+        when(dataCorrectionService.hasCorrectionRule("SUBSCRIBER", "nombre")).thenReturn(false);
+        when(inconsistencyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(
+                Map.<String, Object>of("id", "sub-001"),
+                Map.<String, Object>of("id", "sub-002")
+        );
+
+        // WHEN
+        ValidationResult result = service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN
+        assertThat(result.getTotalRecords()).isEqualTo(2);
+        assertThat(result.getValidRecords()).isEqualTo(0);
+        assertThat(result.getInconsistentRecords()).isEqualTo(2);
+        assertThat(result.getResults()).allMatch(r -> "INCONSISTENT".equals(r.getStatus()));
+    }
+
+    @Test
+    void validateBatch_mixedRecords_returns207Counts() {
+        // GIVEN — 1 válido, 1 inválido
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_NULL", "CRITICAL");
+        var errorDetail = buildError("nombre", "NOT_NULL", "CRITICAL");
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(eq(rule), eq("Aseguradora ABC"))).thenReturn(null);
+        when(dataValidationEngine.applyRule(eq(rule), eq(null))).thenReturn(errorDetail);
+        when(dataCorrectionService.hasCorrectionRule("SUBSCRIBER", "nombre")).thenReturn(false);
+        when(inconsistencyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(
+                Map.<String, Object>of("id", "sub-001", "nombre", "Aseguradora ABC"),
+                Map.<String, Object>of("id", "sub-002")
+        );
+
+        // WHEN
+        ValidationResult result = service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN
+        assertThat(result.getTotalRecords()).isEqualTo(2);
+        assertThat(result.getValidRecords()).isEqualTo(1);
+        assertThat(result.getInconsistentRecords()).isEqualTo(1);
+    }
+
+    // ── validateBatch — Corrección automática ─────────────────────────────
+
+    @Test
+    void validateBatch_correctionApplied_returnsValidatedWithCorrectionFlag() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_EMPTY", "CRITICAL");
+        var errorDetail = buildError("nombre", "NOT_EMPTY", "CRITICAL");
+        var correction = CorrectionResult.builder()
+                .corrected(true)
+                .originalValue("  ")
+                .correctedValue("Agencia Central")
+                .ruleApplied("TRIM")
+                .build();
+
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(eq(rule), any())).thenReturn(errorDetail);
+        when(dataCorrectionService.hasCorrectionRule("SUBSCRIBER", "nombre")).thenReturn(true);
+        when(dataCorrectionService.applyCorrection("SUBSCRIBER", "nombre", "  ")).thenReturn(correction);
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        java.util.Map<String, Object> mutableRecord = new java.util.HashMap<>();
+        mutableRecord.put("id", "sub-001");
+        mutableRecord.put("nombre", "  ");
+        List<java.util.Map<String, Object>> records = List.of(mutableRecord);
+
+        // WHEN
+        ValidationResult result = service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN
+        assertThat(result.getValidRecords()).isEqualTo(1);
+        assertThat(result.getInconsistentRecords()).isEqualTo(0);
+        assertThat(result.getResults().get(0).isCorrectionApplied()).isTrue();
+    }
+
+    @Test
+    void validateBatch_criticalInconsistency_notifiesCritical() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "id", "NOT_NULL", "CRITICAL");
+        var errorDetail = buildError("id", "NOT_NULL", "CRITICAL");
+
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(eq(rule), any())).thenReturn(errorDetail);
+        when(dataCorrectionService.hasCorrectionRule("SUBSCRIBER", "id")).thenReturn(false);
+        when(inconsistencyRepository.save(any())).thenAnswer(inv -> {
+            DataInconsistency di = inv.getArgument(0);
+            di.setId("uuid-saved");
+            return di;
+        });
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(Map.<String, Object>of("nombre", "Aseguradora"));
+
+        // WHEN
+        service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN — la notificación CRITICAL fue invocada
+        verify(notificationService).notifyCritical(any(DataInconsistency.class));
+    }
+
+    @Test
+    void validateBatch_warningInconsistency_doesNotNotifyCritical() {
+        // GIVEN
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_EMPTY", "WARNING");
+        var errorDetail = buildError("nombre", "NOT_EMPTY", "WARNING");
+
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(eq(rule), any())).thenReturn(errorDetail);
+        when(dataCorrectionService.hasCorrectionRule("SUBSCRIBER", "nombre")).thenReturn(false);
+        when(inconsistencyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(Map.<String, Object>of("id", "sub-001"));
+
+        // WHEN
+        service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN — WARNING no activa notificación crítica individual
+        verify(notificationService, never()).notifyCritical(any());
+    }
+
+    // ── validateBatch — Umbral de lote ────────────────────────────────────
+
+    @Test
+    void validateBatch_thresholdExceeded_notifiesBatchThreshold() {
+        // GIVEN — 6 inconsistentes de 6 = 100%, umbral es 10%
+        var rule = buildRule("SUBSCRIBER", "id", "NOT_NULL", "CRITICAL");
+        var errorDetail = buildError("id", "NOT_NULL", "CRITICAL");
+
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(any(), any())).thenReturn(errorDetail);
+        when(dataCorrectionService.hasCorrectionRule(anyString(), anyString())).thenReturn(false);
+        when(inconsistencyRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(
+                Map.<String, Object>of("nombre", "A"),
+                Map.<String, Object>of("nombre", "B"),
+                Map.<String, Object>of("nombre", "C"),
+                Map.<String, Object>of("nombre", "D"),
+                Map.<String, Object>of("nombre", "E"),
+                Map.<String, Object>of("nombre", "F")
+        );
+
+        // WHEN
+        service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN
+        verify(notificationService).notifyBatchThresholdExceeded(eq(6), eq(6), eq("SUBSCRIBER"));
+    }
+
+    @Test
+    void validateBatch_thresholdNotExceeded_doesNotNotifyBatch() {
+        // GIVEN — 1 inconsistente de 100 = 1%, umbral es 10%
+        var rule = buildRule("SUBSCRIBER", "nombre", "NOT_NULL", "CRITICAL");
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of(rule));
+        when(dataValidationEngine.applyRule(eq(rule), any())).thenReturn(null);
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(Map.<String, Object>of("id", "sub-001", "nombre", "Aseg A"));
+
+        // WHEN
+        service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN
+        verify(notificationService, never()).notifyBatchThresholdExceeded(anyInt(), anyInt(), anyString());
+    }
+
+    @Test
+    void validateBatch_emptyRecords_returnsEmptyResult() {
+        // GIVEN
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of());
+        // checkBatchThreshold retorna inmediatamente con total=0, sin consultar el umbral
+
+        // WHEN
+        ValidationResult result = service.validateBatch("SUBSCRIBER", List.of(), "corr-001");
+
+        // THEN
+        assertThat(result.getTotalRecords()).isEqualTo(0);
+        assertThat(result.getValidRecords()).isEqualTo(0);
+        assertThat(result.getInconsistentRecords()).isEqualTo(0);
+    }
+
+    // ── validateBatch — resolveRecordId ───────────────────────────────────
+
+    @Test
+    void validateBatch_recordWithIdField_usesIdAsRecordId() {
+        // GIVEN
+        when(dataValidationEngine.getRulesForDataType("SUBSCRIBER")).thenReturn(List.of());
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(Map.<String, Object>of("id", "sub-999", "nombre", "ABC"));
+
+        // WHEN
+        ValidationResult result = service.validateBatch("SUBSCRIBER", records, "corr-001");
+
+        // THEN
+        assertThat(result.getResults().get(0).getId()).isEqualTo("sub-999");
+    }
+
+    @Test
+    void validateBatch_recordWithCodigoField_usesCodigoAsRecordId() {
+        // GIVEN
+        when(dataValidationEngine.getRulesForDataType("ZIP_CODE")).thenReturn(List.of());
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        var records = List.of(Map.<String, Object>of("codigo", "06600", "ciudad", "CDMX"));
+
+        // WHEN
+        ValidationResult result = service.validateBatch("ZIP_CODE", records, "corr-001");
+
+        // THEN
+        assertThat(result.getResults().get(0).getId()).isEqualTo("06600");
+    }
+
+    // ── getInconsistencies ────────────────────────────────────────────────
+
+    @Test
+    void getInconsistencies_bothFilters_callsFindByDataTypeAndStatus() {
+        // GIVEN
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<DataInconsistency> page = new PageImpl<>(List.of());
+        when(inconsistencyRepository.findByDataTypeAndStatus("SUBSCRIBER", "CRITICAL", pageable))
+                .thenReturn(page);
+
+        // WHEN
+        var result = service.getInconsistencies("SUBSCRIBER", "CRITICAL", pageable);
+
+        // THEN
+        assertThat(result).isNotNull();
+        verify(inconsistencyRepository).findByDataTypeAndStatus("SUBSCRIBER", "CRITICAL", pageable);
+    }
+
+    @Test
+    void getInconsistencies_onlyDataType_callsFindByDataType() {
+        // GIVEN
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<DataInconsistency> page = new PageImpl<>(List.of());
+        when(inconsistencyRepository.findByDataType("TARIFF_CAT", pageable)).thenReturn(page);
+
+        // WHEN
+        service.getInconsistencies("TARIFF_CAT", null, pageable);
+
+        // THEN
+        verify(inconsistencyRepository).findByDataType("TARIFF_CAT", pageable);
+    }
+
+    @Test
+    void getInconsistencies_onlyStatus_callsFindByStatus() {
+        // GIVEN
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<DataInconsistency> page = new PageImpl<>(List.of());
+        when(inconsistencyRepository.findByStatus("WARNING", pageable)).thenReturn(page);
+
+        // WHEN
+        service.getInconsistencies(null, "WARNING", pageable);
+
+        // THEN
+        verify(inconsistencyRepository).findByStatus("WARNING", pageable);
+    }
+
+    @Test
+    void getInconsistencies_noFilters_callsFindAll() {
+        // GIVEN
+        Pageable pageable = PageRequest.of(0, 20);
+        Page<DataInconsistency> page = new PageImpl<>(List.of());
+        when(inconsistencyRepository.findAll(pageable)).thenReturn(page);
+
+        // WHEN
+        service.getInconsistencies(null, null, pageable);
+
+        // THEN
+        verify(inconsistencyRepository).findAll(pageable);
+    }
+
+    @Test
+    void getInconsistencies_withData_returnsPageWithResults() {
+        // GIVEN
+        Pageable pageable = PageRequest.of(0, 20);
+        var inconsistency = DataInconsistency.builder()
+                .id("uuid-001")
+                .dataType("SUBSCRIBER")
+                .dataId("sub-002")
+                .status("CRITICAL")
+                .createdAt(Instant.now())
+                .build();
+        Page<DataInconsistency> page = new PageImpl<>(List.of(inconsistency));
+        when(inconsistencyRepository.findByDataType("SUBSCRIBER", pageable)).thenReturn(page);
+
+        // WHEN
+        var result = service.getInconsistencies("SUBSCRIBER", null, pageable);
+
+        // THEN
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getDataType()).isEqualTo("SUBSCRIBER");
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private ValidationRule buildRule(String dataType, String fieldName, String ruleType, String severity) {
+        return ValidationRule.builder()
+                .dataType(dataType)
+                .fieldName(fieldName)
+                .ruleType(ruleType)
+                .errorMessage("Error en campo '" + fieldName + "'")
+                .severity(severity)
+                .enabled(true)
+                .build();
+    }
+
+    private ValidationErrorDetail buildError(String field, String rule, String severity) {
+        return ValidationErrorDetail.builder()
+                .field(field)
+                .rule(rule)
+                .message("Error en campo '" + field + "'")
+                .severity(severity)
+                .build();
+    }
+}

--- a/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/InconsistencyNotificationServiceImplTest.java
+++ b/plataformas-danos-back/src/test/java/com/plataformas_danos_back/service/InconsistencyNotificationServiceImplTest.java
@@ -1,0 +1,121 @@
+package com.plataformas_danos_back.service;
+
+import com.plataformas_danos_back.config.ValidationProperties;
+import com.plataformas_danos_back.model.entity.DataInconsistency;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InconsistencyNotificationServiceImplTest {
+
+    @Mock
+    private ValidationProperties validationProperties;
+
+    @InjectMocks
+    private InconsistencyNotificationServiceImpl service;
+
+    // ── notifyCritical ────────────────────────────────────────────────────
+
+    @Test
+    void notifyCritical_validInconsistency_doesNotThrow() {
+        // GIVEN
+        var validationError = DataInconsistency.ValidationErrorDetail.builder()
+                .field("nombre")
+                .rule("NOT_NULL")
+                .message("Campo 'nombre' es obligatorio")
+                .severity("CRITICAL")
+                .build();
+        var inconsistency = DataInconsistency.builder()
+                .id("uuid-001")
+                .dataType("SUBSCRIBER")
+                .dataId("sub-002")
+                .validationError(validationError)
+                .correlationId("corr-123")
+                .createdAt(Instant.now())
+                .build();
+
+        // WHEN / THEN — nunca propaga excepción
+        assertThatNoException().isThrownBy(() -> service.notifyCritical(inconsistency));
+    }
+
+    @Test
+    void notifyCritical_nullValidationError_doesNotThrow() {
+        // GIVEN — inconsistencia sin detalle de error (edge case)
+        var inconsistency = DataInconsistency.builder()
+                .id("uuid-002")
+                .dataType("TARIFF_CAT")
+                .dataId("zona-A")
+                .validationError(null)
+                .correlationId("corr-456")
+                .createdAt(Instant.now())
+                .build();
+
+        // WHEN / THEN — campo 'desconocido' se usa como fallback, sin excepción
+        assertThatNoException().isThrownBy(() -> service.notifyCritical(inconsistency));
+    }
+
+    @Test
+    void notifyCritical_nullId_doesNotThrow() {
+        // GIVEN
+        var inconsistency = DataInconsistency.builder()
+                .id(null)
+                .dataType("ZIP_CODE")
+                .dataId(null)
+                .correlationId(null)
+                .createdAt(Instant.now())
+                .build();
+
+        // WHEN / THEN
+        assertThatNoException().isThrownBy(() -> service.notifyCritical(inconsistency));
+    }
+
+    // ── notifyBatchThresholdExceeded ──────────────────────────────────────
+
+    @Test
+    void notifyBatchThresholdExceeded_aboveThreshold_doesNotThrow() {
+        // GIVEN
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        // WHEN / THEN — 6 inconsistentes de 10 = 60%, por encima del umbral 10%
+        assertThatNoException().isThrownBy(
+                () -> service.notifyBatchThresholdExceeded(10, 6, "SUBSCRIBER"));
+    }
+
+    @Test
+    void notifyBatchThresholdExceeded_zeroTotal_doesNotThrowArithmeticException() {
+        // GIVEN — total=0 debería manejar división por cero
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        // WHEN / THEN
+        assertThatNoException().isThrownBy(
+                () -> service.notifyBatchThresholdExceeded(0, 0, "TARIFF_CAT"));
+    }
+
+    @Test
+    void notifyBatchThresholdExceeded_exactlyThreshold_doesNotThrow() {
+        // GIVEN — 1 de 10 = 10%, exactamente igual al umbral
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        // WHEN / THEN
+        assertThatNoException().isThrownBy(
+                () -> service.notifyBatchThresholdExceeded(10, 1, "AGENT"));
+    }
+
+    @Test
+    void notifyBatchThresholdExceeded_logsDataType() {
+        // GIVEN
+        when(validationProperties.getInconsistencyThresholdPercent()).thenReturn(10);
+
+        // WHEN / THEN — verifica que no falla con cualquier tipo de dato
+        assertThatNoException().isThrownBy(
+                () -> service.notifyBatchThresholdExceeded(100, 50, "TARIFF_ELECTRONIC"));
+    }
+}


### PR DESCRIPTION
Capa transversal de validación, inconsistencias y corrección automática de datos maestros con auditoría y alertas

* Se implementa módulo `validation` independiente (`DataValidationService`, `DataValidationEngine`, `DataCorrectionService`, `InconsistencyNotificationService`, `DataValidationController`) desacoplado de catálogos y tarifas
* Se introducen modelos persistentes `DataInconsistency` y `ValidationRule` en MongoDB con índices (dataType, status, dataId) y TTL de 90 días
* Se expone endpoint `POST /api/v1/data-validation/validate` con soporte de respuesta `200` y `207 Multi-Status` para validaciones parciales
* Se agregan endpoints administrativos para gestión de reglas (`GET/POST/PUT /api/v1/data-validation/rules`) con control de acceso por rol ADMIN
* Se implementa motor de reglas configurable (NOT_NULL, NOT_EMPTY, POSITIVE_NUMBER, FORMAT_REGEX, RANGE, ENUM) con severidad (CRITICAL/WARNING/INFO)
* Se registra auditoría completa de inconsistencias (campo, regla, mensaje, severidad, correlationId, timestamp) en colección `data-inconsistencies`
* Se habilita corrección automática controlada (TRIM, DEFAULT_VALUE, NORMALIZE_CASE) preservando `valorOriginal` y trazabilidad de la regla aplicada
* Se integran alertas: logs estructurados `ERROR` para inconsistencias críticas y notificación por umbral de lote configurable (>10%)
* Se garantiza no bloqueo del flujo ante fallos de persistencia o notificación (manejo resiliente con logging)
* Se prepara integración como interceptor/decorator en servicios (`CatalogsService`, `TariffsService`, `ZipCodeService`) para validar antes de exponer datos
* Se implementa caché de reglas (Caffeine) con TTL configurable para optimizar performance
* Se filtran automáticamente registros `INCONSISTENT` evitando exposición al frontend
* Se agregan tests unitarios y de integración para validaciones, engine de reglas, persistencia, corrección automática, notificaciones y endpoints REST
